### PR TITLE
fix: Fixed image not showing issue

### DIFF
--- a/lib/src/widgets/image_message_view.dart
+++ b/lib/src/widgets/image_message_view.dart
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 
@@ -98,10 +98,9 @@ class ImageMessageView extends StatelessWidget {
                   child: ClipRRect(
                     borderRadius: imageMessageConfig?.borderRadius ??
                         BorderRadius.circular(14),
-                    child: imageUrl.fromMemory
-                        ? Image.memory(
-                            base64Decode(imageUrl
-                                .substring(imageUrl.indexOf('base64') + 7)),
+                    child: !imageUrl.isUrl
+                        ? Image.file(
+                            File(imageUrl),
                             fit: BoxFit.fill,
                           )
                         : Image.network(


### PR DESCRIPTION
# Description
This PR is aiming to solve the problem concerning images not showing up when trying to send an image.
In the `ImageMessageView()` file, how images were loaded previously was by checking whether the image `isMemory`. If yes then you used `Image.memory()`. But while I was testing it on my iphone, the local images selected did not start with `data:image` so the `imageUrl` was redirected to use `NetworkImage()` to load them and that was the bug.

What I changed was to use `Image.file(File(imageUrl))` to load the images and I checked whether the `!imageUrl.isUrl` or not using your already built in extension. And it worked fine.

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #60

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org