### PR TITLE
feat: 🌟 Message Reciepts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,27 @@ ChatView(
 )
 ```
 
+18.  Passing customReciepts builder or handling stuffs related reciepts see `RecieptsWidgetConfig` in  outgoingChatBubbleConfig.
+    
+```dart
+ChatView(
+    ...
 
+     ChatBubbleConfiguration(
+          outgoingChatBubbleConfig: ChatBubble(
+              recieptsAndSendingNotifierWidgetConfiguration: RecieptsWidgetConfig(
+                      /// custom reciepts builder 
+                      recieptsBuilder: _customRecieptsBuilder,
+                      /// whether to display reciepts in all 
+                      /// message or just at the last one just like instagram
+                      showRecieptsIn: ShowRecieptsIn.lastMessage
+              ),
+            ), 
+        ), 
+          ...
+ 
+)
+```
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ ChatView(
 
      ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-              recieptsAndSendingNotifierWidgetConfiguration: RecieptsWidgetConfig(
+              recieptsWidgetConfig: RecieptsWidgetConfig(
                       /// custom reciepts builder 
                       recieptsBuilder: _customRecieptsBuilder,
                       /// whether to display reciepts in all 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,27 @@ ChatView(
     ...
 )
 ```
+
+1.  Callback when a user starts/stops typing in `TextFieldConfig`
+    
+```dart
+ChatView(
+    ...
+      sendMessageConfig: SendMessageConfiguration(
+       
+          textFieldConfig: TextFieldConfiguration(
+            onMessageComposition: (status) {
+                // send composing/composed status to other client.
+                // your code goes here
+            },       
+        ),
+    ...
+  )
+)
+```
+
+
+
 ## How to use
 
 Check out [blog](https://medium.com/simform-engineering/chatview-a-cutting-edge-chat-ui-solution-7367b1f9d772) for better understanding and basic implementation. 

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ ChatView(
 )
 ```
 
-1.  Callback when a user starts/stops typing in `TextFieldConfig`
+17.  Callback when a user starts/stops typing in `TextFieldConfiguration`
     
 ```dart
 ChatView(
@@ -407,10 +407,17 @@ ChatView(
       sendMessageConfig: SendMessageConfiguration(
        
           textFieldConfig: TextFieldConfiguration(
-            onMessageComposition: (status) {
-                // send composing/composed status to other client.
+            onMessageTyping: (status) {
+                // send composing/composed status to other client
                 // your code goes here
-            },       
+            },   
+
+            
+        /// After typing stopped, the threshold time after which the composing
+        /// status to be changed to [TypeWriterStatus.composed].
+        /// Default is 1 second.
+            compositionThresholdTime: const Duration(seconds: 1),
+
         ),
     ...
   )

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ ChatView(
 
             
         /// After typing stopped, the threshold time after which the composing
-        /// status to be changed to [TypeWriterStatus.composed].
+        /// status to be changed to [TypeWriterStatus.typed].
         /// Default is 1 second.
             compositionThresholdTime: const Duration(seconds: 1),
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ ChatView(
 )
 ```
 
-18.  Passing customReciepts builder or handling stuffs related reciepts see `RecieptsWidgetConfig` in  outgoingChatBubbleConfig.
+18.  Passing customReceipts builder or handling stuffs related receipts see `ReceiptsWidgetConfig` in  outgoingChatBubbleConfig.
     
 ```dart
 ChatView(
@@ -432,12 +432,12 @@ ChatView(
 
      ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-              recieptsWidgetConfig: RecieptsWidgetConfig(
-                      /// custom reciepts builder 
-                      recieptsBuilder: _customRecieptsBuilder,
-                      /// whether to display reciepts in all 
+              receiptsWidgetConfig: ReceiptsWidgetConfig(
+                      /// custom receipts builder 
+                      receiptsBuilder: _customReceiptsBuilder,
+                      /// whether to display receipts in all 
                       /// message or just at the last one just like instagram
-                      showRecieptsIn: ShowRecieptsIn.lastMessage
+                      showReceiptsIn: ShowReceiptsIn.lastMessage
               ),
             ), 
         ), 

--- a/example/lib/data.dart
+++ b/example/lib/data.dart
@@ -9,6 +9,7 @@ class Data {
       message: "Hi!",
       createdAt: DateTime.now(),
       sendBy: '1', // userId of who sends the message
+      
     ),
     Message(
       id: '2',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -134,9 +134,10 @@ class _ChatScreenState extends State<ChatScreen> {
           textFieldBackgroundColor: theme.textFieldBackgroundColor,
           closeIconColor: theme.closeIconColor,
           textFieldConfig: TextFieldConfiguration(
-            onMessageComposition: (status) {
+            onMessageTyping: (status) {
                 print(status);
             },
+            compositionThresholdTime: const Duration(seconds: 1),
             textStyle: TextStyle(color: theme.textFieldTextColor),
           ),
           micIconColor: theme.replyMicIconColor,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:chatview/chatview.dart';
 import 'package:example/data.dart';
 import 'package:example/models/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 
 void main() {
   runApp(const Example());
@@ -135,7 +136,8 @@ class _ChatScreenState extends State<ChatScreen> {
           closeIconColor: theme.closeIconColor,
           textFieldConfig: TextFieldConfiguration(
             onMessageTyping: (status) {
-                print(status);
+              /// Do with status
+              debugPrint(status.toString());
             },
             compositionThresholdTime: const Duration(seconds: 1),
             textStyle: TextStyle(color: theme.textFieldTextColor),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -134,6 +134,9 @@ class _ChatScreenState extends State<ChatScreen> {
           textFieldBackgroundColor: theme.textFieldBackgroundColor,
           closeIconColor: theme.closeIconColor,
           textFieldConfig: TextFieldConfiguration(
+            onMessageComposition: (status) {
+                print(status);
+            },
             textStyle: TextStyle(color: theme.textFieldTextColor),
           ),
           micIconColor: theme.replyMicIconColor,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -155,20 +155,13 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         chatBubbleConfig: ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-              linkPreviewConfig: LinkPreviewConfiguration(
-                backgroundColor: theme.linkPreviewOutgoingChatColor,
-                bodyStyle: theme.outgoingChatLinkBodyStyle,
-                titleStyle: theme.outgoingChatLinkTitleStyle,
-              ),
-              color: theme.outgoingChatBubbleColor,
-              recieptsAndSendingNotifierWidgetConfiguration:
-                  RecieptsWidgetConfig(
-                      messageSeenAgoRecieptVisible: false,
-                      recieptsBuilder: _customRecieptsBuilder,
-                      showRecieptsIn: ShowRecieptsIn.all
-                      // messageSeenAgoRecieptVisible: ,
-                      // recieptsBuilderVisibility: ,
-                      )),
+            linkPreviewConfig: LinkPreviewConfiguration(
+              backgroundColor: theme.linkPreviewOutgoingChatColor,
+              bodyStyle: theme.outgoingChatLinkBodyStyle,
+              titleStyle: theme.outgoingChatLinkTitleStyle,
+            ),
+            color: theme.outgoingChatBubbleColor,
+          ),
           inComingChatBubbleConfig: ChatBubble(
             linkPreviewConfig: LinkPreviewConfiguration(
               linkStyle: TextStyle(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -154,13 +154,13 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         chatBubbleConfig: ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-              linkPreviewConfig: LinkPreviewConfiguration(
-                backgroundColor: theme.linkPreviewOutgoingChatColor,
-                bodyStyle: theme.outgoingChatLinkBodyStyle,
-                titleStyle: theme.outgoingChatLinkTitleStyle,
-              ),
-              color: theme.outgoingChatBubbleColor,
-             ),
+            linkPreviewConfig: LinkPreviewConfiguration(
+              backgroundColor: theme.linkPreviewOutgoingChatColor,
+              bodyStyle: theme.outgoingChatLinkBodyStyle,
+              titleStyle: theme.outgoingChatLinkTitleStyle,
+            ),
+            color: theme.outgoingChatBubbleColor,
+          ),
           inComingChatBubbleConfig: ChatBubble(
             linkPreviewConfig: LinkPreviewConfiguration(
               linkStyle: TextStyle(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -155,13 +155,20 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         chatBubbleConfig: ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-            linkPreviewConfig: LinkPreviewConfiguration(
-              backgroundColor: theme.linkPreviewOutgoingChatColor,
-              bodyStyle: theme.outgoingChatLinkBodyStyle,
-              titleStyle: theme.outgoingChatLinkTitleStyle,
-            ),
-            color: theme.outgoingChatBubbleColor,
-          ),
+              linkPreviewConfig: LinkPreviewConfiguration(
+                backgroundColor: theme.linkPreviewOutgoingChatColor,
+                bodyStyle: theme.outgoingChatLinkBodyStyle,
+                titleStyle: theme.outgoingChatLinkTitleStyle,
+              ),
+              color: theme.outgoingChatBubbleColor,
+              recieptsAndSendingNotifierWidgetConfiguration:
+                  RecieptsWidgetConfig(
+                      messageSeenAgoRecieptVisible: false,
+                      recieptsBuilder: _customRecieptsBuilder,
+                      showRecieptsIn: ShowRecieptsIn.all
+                      // messageSeenAgoRecieptVisible: ,
+                      // recieptsBuilderVisibility: ,
+                      )),
           inComingChatBubbleConfig: ChatBubble(
             linkPreviewConfig: LinkPreviewConfiguration(
               linkStyle: TextStyle(
@@ -248,6 +255,48 @@ class _ChatScreenState extends State<ChatScreen> {
     );
   }
 
+  Widget _customRecieptsBuilder(MessageStatus status) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10.0),
+      child: SizedBox(
+        child: Align(
+          alignment: Alignment.center,
+          child: Row(children: [
+            if ([
+              MessageStatus.undelivered,
+              MessageStatus.delivered,
+              MessageStatus.read
+            ].contains(status)) ...[
+              SizedBox(
+                child: Icon(
+                  Icons.check_circle_outlined,
+                  size: 14,
+                  color:
+                      status == MessageStatus.read ? Colors.blue : Colors.grey,
+                ),
+              )
+            ],
+            if ([MessageStatus.delivered, MessageStatus.read]
+                .contains(status)) ...[
+              Padding(
+                padding: const EdgeInsets.all(2.0),
+                child: SizedBox(
+                  child: Icon(
+                    Icons.check_circle_outlined,
+                    size: 14,
+                    color: status == MessageStatus.read
+                        ? Colors.blue
+                        : Colors.grey,
+                  ),
+                ),
+              )
+            ],
+          ]),
+        ),
+      ),
+    );
+  }
+
   void _onSendTap(
     String message,
     ReplyMessage replyMessage,
@@ -264,6 +313,13 @@ class _ChatScreenState extends State<ChatScreen> {
         messageType: messageType,
       ),
     );
+    Future.delayed(const Duration(milliseconds: 300), () {
+      _chatController.initialMessageList.last.setStatus =
+          MessageStatus.undelivered;
+    });
+    Future.delayed(const Duration(seconds: 1), () {
+      _chatController.initialMessageList.last.setStatus = MessageStatus.read;
+    });
   }
 
   void _onThemeIconTap() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:chatview/chatview.dart';
 import 'package:example/data.dart';
 import 'package:example/models/theme.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 
 void main() {
   runApp(const Example());
@@ -155,13 +154,13 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         chatBubbleConfig: ChatBubbleConfiguration(
           outgoingChatBubbleConfig: ChatBubble(
-            linkPreviewConfig: LinkPreviewConfiguration(
-              backgroundColor: theme.linkPreviewOutgoingChatColor,
-              bodyStyle: theme.outgoingChatLinkBodyStyle,
-              titleStyle: theme.outgoingChatLinkTitleStyle,
-            ),
-            color: theme.outgoingChatBubbleColor,
-          ),
+              linkPreviewConfig: LinkPreviewConfiguration(
+                backgroundColor: theme.linkPreviewOutgoingChatColor,
+                bodyStyle: theme.outgoingChatLinkBodyStyle,
+                titleStyle: theme.outgoingChatLinkTitleStyle,
+              ),
+              color: theme.outgoingChatBubbleColor,
+             ),
           inComingChatBubbleConfig: ChatBubble(
             linkPreviewConfig: LinkPreviewConfiguration(
               linkStyle: TextStyle(
@@ -243,48 +242,6 @@ class _ChatScreenState extends State<ChatScreen> {
         ),
         swipeToReplyConfig: SwipeToReplyConfiguration(
           replyIconColor: theme.swipeToReplyIconColor,
-        ),
-      ),
-    );
-  }
-
-  Widget _customRecieptsBuilder(MessageStatus status) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 10.0),
-      child: SizedBox(
-        child: Align(
-          alignment: Alignment.center,
-          child: Row(children: [
-            if ([
-              MessageStatus.undelivered,
-              MessageStatus.delivered,
-              MessageStatus.read
-            ].contains(status)) ...[
-              SizedBox(
-                child: Icon(
-                  Icons.check_circle_outlined,
-                  size: 14,
-                  color:
-                      status == MessageStatus.read ? Colors.blue : Colors.grey,
-                ),
-              )
-            ],
-            if ([MessageStatus.delivered, MessageStatus.read]
-                .contains(status)) ...[
-              Padding(
-                padding: const EdgeInsets.all(2.0),
-                child: SizedBox(
-                  child: Icon(
-                    Icons.check_circle_outlined,
-                    size: 14,
-                    color: status == MessageStatus.read
-                        ? Colors.blue
-                        : Colors.grey,
-                  ),
-                ),
-              )
-            ],
-          ]),
         ),
       ),
     );

--- a/lib/chatview.dart
+++ b/lib/chatview.dart
@@ -30,4 +30,5 @@ export 'src/controller/chat_controller.dart';
 export 'src/values/typedefs.dart';
 export 'package:audio_waveforms/audio_waveforms.dart'
     show WaveStyle, PlayerWaveStyle;
+export 'src/models/reciepts_widget_config.dart';
 export 'src/extensions/extensions.dart' show MessageTypes;

--- a/lib/chatview.dart
+++ b/lib/chatview.dart
@@ -30,5 +30,5 @@ export 'src/controller/chat_controller.dart';
 export 'src/values/typedefs.dart';
 export 'package:audio_waveforms/audio_waveforms.dart'
     show WaveStyle, PlayerWaveStyle;
-export 'src/models/reciepts_widget_config.dart';
+export 'src/models/receipts_widget_config.dart';
 export 'src/extensions/extensions.dart' show MessageTypes;

--- a/lib/src/controller/chat_controller.dart
+++ b/lib/src/controller/chat_controller.dart
@@ -74,14 +74,14 @@ class ChatController {
       message.reaction.reactedUserIds.add(userId);
     }
     initialMessageList[indexOfMessage] = Message(
-      id: messageId,
-      message: message.message,
-      createdAt: message.createdAt,
-      sendBy: message.sendBy,
-      replyMessage: message.replyMessage,
-      reaction: message.reaction,
-      messageType: message.messageType,
-    );
+        id: messageId,
+        message: message.message,
+        createdAt: message.createdAt,
+        sendBy: message.sendBy,
+        replyMessage: message.replyMessage,
+        reaction: message.reaction,
+        messageType: message.messageType,
+        status: message.status);
     messageStreamController.sink.add(initialMessageList);
   }
 

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -23,7 +23,7 @@ import 'package:chatview/chatview.dart';
 import 'package:chatview/src/widgets/chat_view_inherited_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 import '../utils/emoji_parser.dart';
 import '../utils/package_strings.dart';
 

--- a/lib/src/models/chat_bubble.dart
+++ b/lib/src/models/chat_bubble.dart
@@ -49,7 +49,7 @@ class ChatBubble {
 
   /// Used to provide builders for last seen message reciept,
   /// at latest outgoing messsage.
-  final RecieptsWidgetConfig? recieptsAndSendingNotifierWidgetConfiguration;
+  final RecieptsWidgetConfig? recieptsWidgetConfig;
 
   ChatBubble(
       {this.color,
@@ -59,5 +59,5 @@ class ChatBubble {
       this.margin,
       this.linkPreviewConfig,
       this.senderNameTextStyle,
-      this.recieptsAndSendingNotifierWidgetConfiguration});
+      this.recieptsWidgetConfig});
 }

--- a/lib/src/models/chat_bubble.dart
+++ b/lib/src/models/chat_bubble.dart
@@ -19,8 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:chatview/src/models/reciepts_widget_config.dart';
 import 'package:flutter/material.dart';
 
+import '../../chatview.dart';
 import 'link_preview_configuration.dart';
 
 class ChatBubble {
@@ -45,13 +47,17 @@ class ChatBubble {
   /// Used to give text style of message sender name.
   final TextStyle? senderNameTextStyle;
 
-  ChatBubble({
-    this.color,
-    this.borderRadius,
-    this.textStyle,
-    this.padding,
-    this.margin,
-    this.linkPreviewConfig,
-    this.senderNameTextStyle,
-  });
+  /// Used to provide builders for last seen message reciept,
+  /// at latest outgoing messsage.
+  final RecieptsWidgetConfig? recieptsAndSendingNotifierWidgetConfiguration;
+
+  ChatBubble(
+      {this.color,
+      this.borderRadius,
+      this.textStyle,
+      this.padding,
+      this.margin,
+      this.linkPreviewConfig,
+      this.senderNameTextStyle,
+      this.recieptsAndSendingNotifierWidgetConfiguration});
 }

--- a/lib/src/models/chat_bubble.dart
+++ b/lib/src/models/chat_bubble.dart
@@ -46,7 +46,7 @@ class ChatBubble {
 
   /// Used to provide builders for last seen message reciept,
   /// at latest outgoing messsage.
-  final RecieptsWidgetConfig? recieptsWidgetConfig;
+  final ReceiptsWidgetConfig? receiptsWidgetConfig;
 
   ChatBubble(
       {this.color,
@@ -56,5 +56,5 @@ class ChatBubble {
       this.margin,
       this.linkPreviewConfig,
       this.senderNameTextStyle,
-      this.recieptsWidgetConfig});
+      this.receiptsWidgetConfig});
 }

--- a/lib/src/models/chat_bubble.dart
+++ b/lib/src/models/chat_bubble.dart
@@ -19,11 +19,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import 'package:chatview/src/models/reciepts_widget_config.dart';
 import 'package:flutter/material.dart';
-
 import '../../chatview.dart';
-import 'link_preview_configuration.dart';
 
 class ChatBubble {
   /// Used for giving color of chat bubble.

--- a/lib/src/models/chat_bubble_configuration.dart
+++ b/lib/src/models/chat_bubble_configuration.dart
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import 'package:chatview/src/models/reciepts_widget_config.dart';
+import 'package:chatview/src/models/receipts_widget_config.dart';
 import 'package:flutter/material.dart';
 
 import '../values/typedefs.dart';
@@ -47,7 +47,7 @@ class ChatBubbleConfiguration {
   /// Provides callback when user tap twice on chat bubble.
   final MessageCallBack? onDoubleTap;
 
-  final RecieptsWidgetConfig? recieptsWidgetConfig;
+  final ReceiptsWidgetConfig? receiptsWidgetConfig;
 
   ChatBubbleConfiguration(
       {this.padding,
@@ -57,5 +57,5 @@ class ChatBubbleConfiguration {
       this.inComingChatBubbleConfig,
       this.outgoingChatBubbleConfig,
       this.onDoubleTap,
-      this.recieptsWidgetConfig});
+      this.receiptsWidgetConfig});
 }

--- a/lib/src/models/chat_bubble_configuration.dart
+++ b/lib/src/models/chat_bubble_configuration.dart
@@ -47,7 +47,7 @@ class ChatBubbleConfiguration {
   /// Provides callback when user tap twice on chat bubble.
   final MessageCallBack? onDoubleTap;
 
-  final RecieptsWidgetConfig? recieptsAndSendingNotifierWidgetConfiguration;
+  final RecieptsWidgetConfig? recieptsWidgetConfig;
 
   ChatBubbleConfiguration(
       {this.padding,
@@ -57,5 +57,5 @@ class ChatBubbleConfiguration {
       this.inComingChatBubbleConfig,
       this.outgoingChatBubbleConfig,
       this.onDoubleTap,
-      this.recieptsAndSendingNotifierWidgetConfiguration});
+      this.recieptsWidgetConfig});
 }

--- a/lib/src/models/chat_bubble_configuration.dart
+++ b/lib/src/models/chat_bubble_configuration.dart
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:chatview/src/models/reciepts_widget_config.dart';
 import 'package:flutter/material.dart';
 
 import '../values/typedefs.dart';
@@ -46,13 +47,15 @@ class ChatBubbleConfiguration {
   /// Provides callback when user tap twice on chat bubble.
   final MessageCallBack? onDoubleTap;
 
-  ChatBubbleConfiguration({
-    this.padding,
-    this.margin,
-    this.maxWidth,
-    this.longPressAnimationDuration,
-    this.inComingChatBubbleConfig,
-    this.outgoingChatBubbleConfig,
-    this.onDoubleTap,
-  });
+  final RecieptsWidgetConfig? recieptsAndSendingNotifierWidgetConfiguration;
+
+  ChatBubbleConfiguration(
+      {this.padding,
+      this.margin,
+      this.maxWidth,
+      this.longPressAnimationDuration,
+      this.inComingChatBubbleConfig,
+      this.outgoingChatBubbleConfig,
+      this.onDoubleTap,
+      this.recieptsAndSendingNotifierWidgetConfiguration});
 }

--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -48,6 +48,9 @@ class Message {
   /// Provides message type.
   final MessageType messageType;
 
+  /// Status of the message.
+  final ValueNotifier<MessageStatus> _status;
+
   /// Provides max duration for recorded voice message.
   Duration? voiceMessageDuration;
 
@@ -60,8 +63,10 @@ class Message {
     Reaction? reaction,
     this.messageType = MessageType.text,
     this.voiceMessageDuration,
+    MessageStatus status = MessageStatus.pending,
   })  : reaction = reaction ?? Reaction(reactions: [], reactedUserIds: []),
         key = GlobalKey(),
+        _status = ValueNotifier(status),
         assert(
           (messageType.isVoice
               ? ((defaultTargetPlatform == TargetPlatform.iOS ||
@@ -69,6 +74,15 @@ class Message {
               : true),
           "Voice messages are only supported with android and ios platform",
         );
+
+  MessageStatus get status => _status.value;
+
+  ValueNotifier<MessageStatus> get statusNotifier => _status;
+
+
+  set setStatus(MessageStatus messageStatus) {
+    _status.value = messageStatus;
+  }
 
   factory Message.fromJson(Map<String, dynamic> json) => Message(
         id: json["id"],

--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -75,11 +75,17 @@ class Message {
           "Voice messages are only supported with android and ios platform",
         );
 
+  /// curret messageStatus
   MessageStatus get status => _status.value;
 
+  /// For [MessageStatus] ValueNotfier which is used to for rebuilds
+  /// when state changes.
+  /// Using ValueNotfier to avoid usage of setState((){}) in order 
+  /// rerender messages with new reciepts.
   ValueNotifier<MessageStatus> get statusNotifier => _status;
 
-
+  /// This setter can be used to update message reciepts, after which the configured
+  /// builders will be updated.
   set setStatus(MessageStatus messageStatus) {
     _status.value = messageStatus;
   }

--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -80,11 +80,11 @@ class Message {
 
   /// For [MessageStatus] ValueNotfier which is used to for rebuilds
   /// when state changes.
-  /// Using ValueNotfier to avoid usage of setState((){}) in order 
-  /// rerender messages with new reciepts.
+  /// Using ValueNotfier to avoid usage of setState((){}) in order
+  /// rerender messages with new receipts.
   ValueNotifier<MessageStatus> get statusNotifier => _status;
 
-  /// This setter can be used to update message reciepts, after which the configured
+  /// This setter can be used to update message receipts, after which the configured
   /// builders will be updated.
   set setStatus(MessageStatus messageStatus) {
     _status.value = messageStatus;

--- a/lib/src/models/receipts_widget_config.dart
+++ b/lib/src/models/receipts_widget_config.dart
@@ -24,32 +24,32 @@ import 'package:flutter/cupertino.dart';
 import '../../chatview.dart';
 import '../utils/constants/constants.dart';
 
-class RecieptsWidgetConfig {
+class ReceiptsWidgetConfig {
   /// The builder that builds widget that right next to the senders message bubble.
   /// Right now it's implemented to show animation only at the last message just
   /// like instagram.
   /// By default [sendMessageAnimationBuilder]
-  final Widget Function(MessageStatus status)? recieptsBuilder;
+  final Widget Function(MessageStatus status)? receiptsBuilder;
 
-  /// Just like Instagram messages reciepts are displayed at the bottom of last
+  /// Just like Instagram messages receipts are displayed at the bottom of last
   /// message. If in case you want to modify it using your custom widget you can
   /// utilize this function.
   final Widget Function(Message message, String formattedDate)?
       lastSeenAgoBuilder;
 
-  /// Controls the visibility of message seen ago reciepts default is true
+  /// Controls the visibility of message seen ago receipts default is true
   final bool messageSeenAgoRecieptVisible;
 
-  /// Controls the visibility of the message [recieptsBuilder]
-  final bool recieptsBuilderVisibility;
+  /// Controls the visibility of the message [receiptsBuilder]
+  final bool receiptsBuilderVisibility;
 
-  /// Whether to show reciepts in all messages or not defaults to [ShowRecieptsIn.lastMessage]
-  final ShowRecieptsIn showRecieptsIn;
+  /// Whether to show receipts in all messages or not defaults to [ShowReceiptsIn.lastMessage]
+  final ShowReceiptsIn showReceiptsIn;
 
-  const RecieptsWidgetConfig(
-      {this.recieptsBuilder,
+  const ReceiptsWidgetConfig(
+      {this.receiptsBuilder,
       this.lastSeenAgoBuilder,
       this.messageSeenAgoRecieptVisible = true,
-      this.recieptsBuilderVisibility = true,
-      this.showRecieptsIn = ShowRecieptsIn.lastMessage});
+      this.receiptsBuilderVisibility = true,
+      this.showReceiptsIn = ShowReceiptsIn.lastMessage});
 }

--- a/lib/src/models/reciepts_widget_config.dart
+++ b/lib/src/models/reciepts_widget_config.dart
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022 Simform Solutions
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import 'package:flutter/cupertino.dart';
+import '../../chatview.dart';
+import '../utils/constants/constants.dart';
+
+class RecieptsWidgetConfig {
+  /// The builder that builds widget that right next to the senders message bubble.
+  /// Right now it's implemented to show animation only at the last message just
+  /// like instagram.
+  /// By default [sendMessageAnimationBuilder]
+  final Widget Function(MessageStatus status)? recieptsBuilder;
+
+  /// Just like Instagram messages reciepts are displayed at the bottom of last
+  /// message. If in case you want to modify it using your custom widget you can
+  /// utilize this function.
+  final Widget Function(Message message, String formattedDate)?
+      lastSeenAgoBuilder;
+
+  /// Controls the visibility of message seen ago reciepts default is true
+  final bool messageSeenAgoRecieptVisible;
+
+  /// Controls the visibility of the message [recieptsBuilder]
+  final bool recieptsBuilderVisibility;
+
+  /// Whether to show reciepts in all messages or not defaults to [ShowRecieptsIn.lastMessage]
+  final ShowRecieptsIn showRecieptsIn;
+
+  const RecieptsWidgetConfig(
+      {this.recieptsBuilder,
+      this.lastSeenAgoBuilder,
+      this.messageSeenAgoRecieptVisible = true,
+      this.recieptsBuilderVisibility = true,
+      this.showRecieptsIn = ShowRecieptsIn.lastMessage});
+}

--- a/lib/src/models/send_message_configuration.dart
+++ b/lib/src/models/send_message_configuration.dart
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 import 'package:audio_waveforms/audio_waveforms.dart';
+import 'package:chatview/src/values/enumaration.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -134,6 +135,14 @@ class TextFieldConfiguration {
   /// Used to give textCapitalization enums to text field.
   TextCapitalization? textCapitalization;
 
+  /// Callback when a user starts/stops typing a message by [ComposingStatus]
+  final void Function(ComposingStatus status)? onMessageComposition;
+
+  /// After typing stopped, the threshold time after which the composing
+  /// status to be changed to [ComposingStatus.composed].
+  /// Default is 1 second.
+  final Duration? compositionThresholdTime;
+
   TextFieldConfiguration({
     this.contentPadding,
     this.maxLines,
@@ -145,6 +154,8 @@ class TextFieldConfiguration {
     this.margin,
     this.minLines,
     this.textInputType,
+    this.onMessageComposition,
+    this.compositionThresholdTime,
     this.inputFormatters,
     this.textCapitalization,
   });

--- a/lib/src/models/send_message_configuration.dart
+++ b/lib/src/models/send_message_configuration.dart
@@ -135,13 +135,13 @@ class TextFieldConfiguration {
   /// Used to give textCapitalization enums to text field.
   TextCapitalization? textCapitalization;
 
-  /// Callback when a user starts/stops typing a message by [ComposingStatus]
-  final void Function(ComposingStatus status)? onMessageComposition;
+  /// Callback when a user starts/stops typing a message by [TypeWriterStatus]
+  final void Function(TypeWriterStatus status)? onMessageTyping;
 
   /// After typing stopped, the threshold time after which the composing
-  /// status to be changed to [ComposingStatus.composed].
+  /// status to be changed to [TypeWriterStatus.composed].
   /// Default is 1 second.
-  final Duration? compositionThresholdTime;
+  final Duration compositionThresholdTime;
 
   TextFieldConfiguration({
     this.contentPadding,
@@ -154,8 +154,8 @@ class TextFieldConfiguration {
     this.margin,
     this.minLines,
     this.textInputType,
-    this.onMessageComposition,
-    this.compositionThresholdTime,
+    this.onMessageTyping,
+    this.compositionThresholdTime = const Duration(seconds: 1),
     this.inputFormatters,
     this.textCapitalization,
   });

--- a/lib/src/models/send_message_configuration.dart
+++ b/lib/src/models/send_message_configuration.dart
@@ -61,6 +61,8 @@ class SendMessageConfiguration {
   /// Styling configuration for recorder widget.
   final VoiceRecordingConfiguration? voiceRecordingConfiguration;
 
+
+
   SendMessageConfiguration({
     this.textFieldConfig,
     this.textFieldBackgroundColor,

--- a/lib/src/utils/constants/constants.dart
+++ b/lib/src/utils/constants/constants.dart
@@ -67,7 +67,7 @@ applicationDateFormatter(DateTime inputTime) {
   }
 }
 
-/// Default widget that appears on reciepts at [MessageStatus.pending] when a message
+/// Default widget that appears on receipts at [MessageStatus.pending] when a message
 /// is not sent or at the pending state. A custom implementation can have different
 /// widgets for different states.
 /// Right now it is implemented to appear right next to the outgoing bubble.

--- a/lib/src/utils/constants/constants.dart
+++ b/lib/src/utils/constants/constants.dart
@@ -19,6 +19,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import '../../../chatview.dart';
+import '../../widgets/chat_message_sending_to_sent_animation.dart';
+
 const String enUS = "en_US";
 const String emojiRegExpression =
     r'(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])';
@@ -51,3 +58,31 @@ const double replyBorderRadius1 = 30;
 const double replyBorderRadius2 = 18;
 const double leftPadding3 = 12;
 const double textFieldBorderRadius = 27;
+
+applicationDateFormatter(DateTime inputTime) {
+  if (DateTime.now().difference(inputTime).inDays <= 3) {
+    return timeago.format(inputTime);
+  } else {
+    return DateFormat('dd MMM yyyy').format(inputTime);
+  }
+}
+
+/// Default widget that appears on reciepts at [MessageStatus.pending] when a message
+/// is not sent or at the pending state. A custom implementation can have different
+/// widgets for different states.
+/// Right now it is implemented to appear right next to the outgoing bubble.
+Widget sendMessageAnimationBuilder(MessageStatus status) {
+  return SendingMessageAnimatingWidget(status);
+}
+
+/// Default builder when the message has got seen as of now
+/// is visible at the bottom of the chat bubble
+Widget lastSeenAgoBuilder(Message message, String formattedDate) {
+  return Padding(
+    padding: const EdgeInsets.all(2),
+    child: Text(
+      'Seen ${applicationDateFormatter(message.createdAt)}    ',
+      style: const TextStyle(color: Colors.grey, fontSize: 12),
+    ),
+  );
+}

--- a/lib/src/utils/debounce.dart
+++ b/lib/src/utils/debounce.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+class Debouncer {
+  Timer? _debounce;
+  Duration duration;
+
+  Debouncer(this.duration);
+
+  void run(VoidCallback callbackAfterTimeLapsed,
+      VoidCallback callbackBeforeTimeLapsed) {
+    if (_debounce?.isActive ?? false) {
+      callbackBeforeTimeLapsed();
+      _debounce?.cancel();
+    }
+    _debounce = Timer(duration, callbackAfterTimeLapsed);
+  }
+
+  void dispose() {
+    _debounce?.cancel();
+  }
+}

--- a/lib/src/values/custom_time_messages.dart
+++ b/lib/src/values/custom_time_messages.dart
@@ -1,0 +1,40 @@
+import 'package:timeago/timeago.dart';
+
+// Override "en" locale messages with custom messages that are more precise and short
+// setLocaleMessages('en', MyCustomMessages())
+
+// my_custom_messages.dart
+class MyCustomMessages implements LookupMessages {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => '';
+  @override
+  String suffixAgo() => '';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds) => 'now';
+  @override
+  String aboutAMinute(int minutes) => '$minutes m ago';
+  @override
+  String minutes(int minutes) => '$minutes m ago';
+  @override
+  String aboutAnHour(int minutes) => '$minutes m ago';
+  @override
+  String hours(int hours) => '$hours h ago';
+  @override
+  String aDay(int hours) => '$hours h ago';
+  @override
+  String days(int days) => '$days d ago';
+  @override
+  String aboutAMonth(int days) => '$days d ago';
+  @override
+  String months(int months) => '$months mo ago';
+  @override
+  String aboutAYear(int year) => '$year y ago';
+  @override
+  String years(int years) => '$years y ago';
+  @override
+  String wordSeparator() => ' ';
+}

--- a/lib/src/values/enumaration.dart
+++ b/lib/src/values/enumaration.dart
@@ -30,7 +30,7 @@ enum MessageType {
   custom
 }
 
-enum ComposingStatus { composing, composed }
+enum TypeWriterStatus { typing, typed }
 
 /// Types of states
 enum ChatViewState { hasMessages, noData, loading, error }

--- a/lib/src/values/enumaration.dart
+++ b/lib/src/values/enumaration.dart
@@ -30,6 +30,8 @@ enum MessageType {
   custom
 }
 
+enum ComposingStatus { composing, composed }
+
 /// Types of states
 enum ChatViewState { hasMessages, noData, loading, error }
 

--- a/lib/src/values/enumaration.dart
+++ b/lib/src/values/enumaration.dart
@@ -29,7 +29,8 @@ enum MessageType {
   voice,
   custom
 }
-
+/// Events, Wheter the user is still typing a message or has 
+/// typed the message
 enum TypeWriterStatus { typing, typed }
 
 /// Types of states

--- a/lib/src/values/enumaration.dart
+++ b/lib/src/values/enumaration.dart
@@ -35,13 +35,13 @@ enum MessageType {
 enum TypeWriterStatus { typing, typed }
 
 /// [MessageStatus] defines the current state of the message
-/// if you are sender sending a message then, the 
+/// if you are sender sending a message then, the
 enum MessageStatus { read, delivered, undelivered, pending }
 
 /// Types of states
 enum ChatViewState { hasMessages, noData, loading, error }
 
-enum ShowRecieptsIn {all,lastMessage}
+enum ShowReceiptsIn { all, lastMessage }
 
 extension ChatViewStateExtension on ChatViewState {
   bool get hasMessages => this == ChatViewState.hasMessages;

--- a/lib/src/values/enumaration.dart
+++ b/lib/src/values/enumaration.dart
@@ -29,12 +29,19 @@ enum MessageType {
   voice,
   custom
 }
-/// Events, Wheter the user is still typing a message or has 
+
+/// Events, Wheter the user is still typing a message or has
 /// typed the message
 enum TypeWriterStatus { typing, typed }
 
+/// [MessageStatus] defines the current state of the message
+/// if you are sender sending a message then, the 
+enum MessageStatus { read, delivered, undelivered, pending }
+
 /// Types of states
 enum ChatViewState { hasMessages, noData, loading, error }
+
+enum ShowRecieptsIn {all,lastMessage}
 
 extension ChatViewStateExtension on ChatViewState {
   bool get hasMessages => this == ChatViewState.hasMessages;

--- a/lib/src/widgets/chat_bubble_widget.dart
+++ b/lib/src/widgets/chat_bubble_widget.dart
@@ -247,23 +247,17 @@ class _ChatBubbleWidgetState extends State<ChatBubbleWidget> {
 
   Widget getReciept() {
     final showReciepts = widget.chatBubbleConfig?.outgoingChatBubbleConfig
-            ?.recieptsAndSendingNotifierWidgetConfiguration?.showRecieptsIn ??
+            ?.recieptsWidgetConfig?.showRecieptsIn ??
         ShowRecieptsIn.lastMessage;
     if (showReciepts == ShowRecieptsIn.all) {
       return ValueListenableBuilder(
         valueListenable: widget.message.statusNotifier,
         builder: (context, value, child) {
-          if (widget
-                  .chatBubbleConfig
-                  ?.outgoingChatBubbleConfig
-                  ?.recieptsAndSendingNotifierWidgetConfiguration
-                  ?.recieptsBuilderVisibility ??
+          if (widget.chatBubbleConfig?.outgoingChatBubbleConfig
+                  ?.recieptsWidgetConfig?.recieptsBuilderVisibility ??
               true) {
-            return widget
-                    .chatBubbleConfig
-                    ?.outgoingChatBubbleConfig
-                    ?.recieptsAndSendingNotifierWidgetConfiguration
-                    ?.recieptsBuilder
+            return widget.chatBubbleConfig?.outgoingChatBubbleConfig
+                    ?.recieptsWidgetConfig?.recieptsBuilder
                     ?.call(value as MessageStatus) ??
                 sendMessageAnimationBuilder(value as MessageStatus);
           }
@@ -275,24 +269,18 @@ class _ChatBubbleWidgetState extends State<ChatBubbleWidget> {
           valueListenable:
               chatController!.initialMessageList.last.statusNotifier,
           builder: (context, value, child) {
-            if (widget
-                    .chatBubbleConfig
-                    ?.outgoingChatBubbleConfig
-                    ?.recieptsAndSendingNotifierWidgetConfiguration
-                    ?.recieptsBuilderVisibility ??
+            if (widget.chatBubbleConfig?.outgoingChatBubbleConfig
+                    ?.recieptsWidgetConfig?.recieptsBuilderVisibility ??
                 true) {
-              return widget
-                      .chatBubbleConfig
-                      ?.outgoingChatBubbleConfig
-                      ?.recieptsAndSendingNotifierWidgetConfiguration
-                      ?.recieptsBuilder
+              return widget.chatBubbleConfig?.outgoingChatBubbleConfig
+                      ?.recieptsWidgetConfig?.recieptsBuilder
                       ?.call(value as MessageStatus) ??
                   sendMessageAnimationBuilder(value as MessageStatus);
             }
             return sendMessageAnimationBuilder(value as MessageStatus);
           });
     }
-    return SizedBox();
+    return const SizedBox();
   }
 
   void _onAvatarLongPress(ChatUser? user) {

--- a/lib/src/widgets/chat_bubble_widget.dart
+++ b/lib/src/widgets/chat_bubble_widget.dart
@@ -246,34 +246,34 @@ class _ChatBubbleWidgetState extends State<ChatBubbleWidget> {
   }
 
   Widget getReciept() {
-    final showReciepts = widget.chatBubbleConfig?.outgoingChatBubbleConfig
-            ?.recieptsWidgetConfig?.showRecieptsIn ??
-        ShowRecieptsIn.lastMessage;
-    if (showReciepts == ShowRecieptsIn.all) {
+    final showReceipts = widget.chatBubbleConfig?.outgoingChatBubbleConfig
+            ?.receiptsWidgetConfig?.showReceiptsIn ??
+        ShowReceiptsIn.lastMessage;
+    if (showReceipts == ShowReceiptsIn.all) {
       return ValueListenableBuilder(
         valueListenable: widget.message.statusNotifier,
         builder: (context, value, child) {
           if (widget.chatBubbleConfig?.outgoingChatBubbleConfig
-                  ?.recieptsWidgetConfig?.recieptsBuilderVisibility ??
+                  ?.receiptsWidgetConfig?.receiptsBuilderVisibility ??
               true) {
             return widget.chatBubbleConfig?.outgoingChatBubbleConfig
-                    ?.recieptsWidgetConfig?.recieptsBuilder
+                    ?.receiptsWidgetConfig?.receiptsBuilder
                     ?.call(value as MessageStatus) ??
                 sendMessageAnimationBuilder(value as MessageStatus);
           }
           return const SizedBox();
         },
       );
-    } else if (showReciepts == ShowRecieptsIn.lastMessage && isLastMessage) {
+    } else if (showReceipts == ShowReceiptsIn.lastMessage && isLastMessage) {
       return ValueListenableBuilder(
           valueListenable:
               chatController!.initialMessageList.last.statusNotifier,
           builder: (context, value, child) {
             if (widget.chatBubbleConfig?.outgoingChatBubbleConfig
-                    ?.recieptsWidgetConfig?.recieptsBuilderVisibility ??
+                    ?.receiptsWidgetConfig?.receiptsBuilderVisibility ??
                 true) {
               return widget.chatBubbleConfig?.outgoingChatBubbleConfig
-                      ?.recieptsWidgetConfig?.recieptsBuilder
+                      ?.receiptsWidgetConfig?.receiptsBuilder
                       ?.call(value as MessageStatus) ??
                   sendMessageAnimationBuilder(value as MessageStatus);
             }

--- a/lib/src/widgets/chat_message_sending_to_sent_animation.dart
+++ b/lib/src/widgets/chat_message_sending_to_sent_animation.dart
@@ -1,0 +1,68 @@
+import 'dart:math';
+import 'package:chatview/chatview.dart';
+import 'package:flutter/material.dart';
+
+class SendingMessageAnimatingWidget extends StatefulWidget {
+  const SendingMessageAnimatingWidget(this.status, {Key? key})
+      : super(key: key);
+
+  final MessageStatus status;
+
+  @override
+  State<SendingMessageAnimatingWidget> createState() =>
+      _SendingMessageAnimatingWidgetState();
+}
+
+class _SendingMessageAnimatingWidgetState
+    extends State<SendingMessageAnimatingWidget> with TickerProviderStateMixin {
+      
+  bool get isSent => widget.status != MessageStatus.pending;
+
+  bool isVisible = false;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  _attachOnStatusChangeListeners() {
+    if (isSent) {
+      Future.delayed(const Duration(milliseconds: 400), () {
+        isVisible = true;
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _attachOnStatusChangeListeners();
+    return AnimatedPadding(
+      curve: Curves.easeInOutExpo,
+      duration: const Duration(seconds: 1),
+      padding: EdgeInsets.only(right: isSent ? 5 : 8.0, bottom: isSent ? 8 : 2),
+      child: isVisible
+          ? const SizedBox()
+          : Transform.rotate(
+              angle: !isSent ? pi / 10 : -pi / 12,
+              child: const Padding(
+                padding: EdgeInsets.only(
+                  left: 2,
+                  bottom: 5,
+                ),
+                child: Icon(
+                  Icons.send,
+                  color: Colors.grey,
+                  size: 12,
+                ),
+              )),
+    );
+  }
+}

--- a/lib/src/widgets/chat_view.dart
+++ b/lib/src/widgets/chat_view.dart
@@ -23,9 +23,9 @@ import 'package:chatview/chatview.dart';
 import 'package:chatview/src/widgets/chat_list_widget.dart';
 import 'package:chatview/src/widgets/chatview_state_widget.dart';
 import 'package:chatview/src/widgets/chat_view_inherited_widget.dart';
-
 import 'package:flutter/material.dart';
-
+import 'package:timeago/timeago.dart';
+import '../values/custom_time_messages.dart';
 import 'send_message_widget.dart';
 
 class ChatView extends StatefulWidget {
@@ -131,6 +131,8 @@ class ChatView extends StatefulWidget {
   /// Provides parameter so user can assign ChatViewAppbar.
   final Widget? appBar;
 
+
+
   @override
   State<ChatView> createState() => _ChatViewState();
 }
@@ -157,6 +159,7 @@ class _ChatViewState extends State<ChatView>
   @override
   void initState() {
     super.initState();
+    setLocaleMessages('en', MyCustomMessages());
     // Adds current user in users list.
     chatController.chatUsers.add(widget.currentUser);
   }

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -27,7 +27,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../chatview.dart';
 import 'dart:async';
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 import '../utils/debounce.dart';
 import '../utils/package_strings.dart';
 

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -27,7 +27,6 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../chatview.dart';
 import 'dart:async';
-import 'package:stream_transform/stream_transform.dart';
 import '../utils/constants.dart';
 import '../utils/debounce.dart';
 import '../utils/package_strings.dart';

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -166,9 +166,7 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                 minLines: textFieldConfig?.minLines ?? 1,
                 keyboardType: textFieldConfig?.textInputType,
                 inputFormatters: textFieldConfig?.inputFormatters,
-                onChanged: (str) {
-                  _onChanged(str);
-                },
+                onChanged: _onChanged,
                 textCapitalization: textFieldConfig?.textCapitalization ??
                     TextCapitalization.sentences,
                 decoration: InputDecoration(

--- a/lib/src/widgets/emoji_row.dart
+++ b/lib/src/widgets/emoji_row.dart
@@ -21,7 +21,7 @@
  */
 import 'package:flutter/material.dart';
 import 'package:chatview/src/models/reaction_popup_configuration.dart';
-import 'package:chatview/src/utils/constants.dart';
+import 'package:chatview/src/utils/constants/constants.dart';
 
 import '../values/typedefs.dart';
 import 'emoji_picker_widget.dart';

--- a/lib/src/widgets/glassmorphism_reaction_popup.dart
+++ b/lib/src/widgets/glassmorphism_reaction_popup.dart
@@ -24,7 +24,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 import '../models/models.dart';
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 
 class GlassMorphismReactionPopup extends StatelessWidget {
   const GlassMorphismReactionPopup({

--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -25,7 +25,7 @@ import 'package:chatview/src/models/link_preview_configuration.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 
 class LinkPreview extends StatelessWidget {
   const LinkPreview({

--- a/lib/src/widgets/message_view.dart
+++ b/lib/src/widgets/message_view.dart
@@ -238,14 +238,10 @@ class _MessageViewState extends State<MessageView>
                   widget.controller?.initialMessageList.last.id ==
                       widget.message.id &&
                   widget.message.status == MessageStatus.read) {
-                if (widget
-                        .outgoingChatBubbleConfig
-                        ?.recieptsAndSendingNotifierWidgetConfiguration
+                if (widget.outgoingChatBubbleConfig?.recieptsWidgetConfig
                         ?.messageSeenAgoRecieptVisible ??
                     true) {
-                  return widget
-                          .outgoingChatBubbleConfig
-                          ?.recieptsAndSendingNotifierWidgetConfiguration
+                  return widget.outgoingChatBubbleConfig?.recieptsWidgetConfig
                           ?.lastSeenAgoBuilder
                           ?.call(
                               widget.message,

--- a/lib/src/widgets/message_view.dart
+++ b/lib/src/widgets/message_view.dart
@@ -19,13 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:chatview/chatview.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chatview/src/extensions/extensions.dart';
-import 'package:chatview/src/models/models.dart';
-
-import '../utils/constants.dart';
-import '../values/typedefs.dart';
+import '../utils/constants/constants.dart';
 import 'image_message_view.dart';
 import 'text_message_view.dart';
 import 'reaction_widget.dart';
@@ -48,6 +46,7 @@ class MessageView extends StatefulWidget {
     this.highlightScale = 1.2,
     this.messageConfig,
     this.onMaxDuration,
+    this.controller,
   }) : super(key: key);
 
   /// Provides message instance of chat.
@@ -89,6 +88,9 @@ class MessageView extends StatefulWidget {
 
   /// Allow user to turn on/off long press tap on chat bubble.
   final bool isLongPressEnable;
+
+  final ChatController? controller;
+
   final Function(int)? onMaxDuration;
 
   @override
@@ -154,72 +156,111 @@ class _MessageViewState extends State<MessageView>
       padding: EdgeInsets.only(
         bottom: widget.message.reaction.reactions.isNotEmpty ? 6 : 0,
       ),
-      child: (() {
-        if (message.isAllEmoji) {
-          return Stack(
-            clipBehavior: Clip.none,
-            children: [
-              Padding(
-                padding: emojiMessageConfiguration?.padding ??
-                    EdgeInsets.fromLTRB(
-                      leftPadding2,
-                      4,
-                      leftPadding2,
-                      widget.message.reaction.reactions.isNotEmpty ? 14 : 0,
-                    ),
-                child: Transform.scale(
-                  scale: widget.shouldHighlight ? widget.highlightScale : 1.0,
-                  child: Text(
-                    message,
-                    style: emojiMessageConfiguration?.textStyle ??
-                        const TextStyle(fontSize: 30),
-                  ),
-                ),
-              ),
-              if (widget.message.reaction.reactions.isNotEmpty)
-                ReactionWidget(
-                  reaction: widget.message.reaction,
-                  messageReactionConfig: messageConfig?.messageReactionConfig,
-                  isMessageBySender: widget.isMessageBySender,
-                ),
-            ],
-          );
-        } else if (widget.message.messageType.isImage) {
-          return ImageMessageView(
-            message: widget.message,
-            isMessageBySender: widget.isMessageBySender,
-            imageMessageConfig: messageConfig?.imageMessageConfig,
-            messageReactionConfig: messageConfig?.messageReactionConfig,
-            highlightImage: widget.shouldHighlight,
-            highlightScale: widget.highlightScale,
-          );
-        } else if (widget.message.messageType.isText) {
-          return TextMessageView(
-            inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
-            outgoingChatBubbleConfig: widget.outgoingChatBubbleConfig,
-            isMessageBySender: widget.isMessageBySender,
-            message: widget.message,
-            chatBubbleMaxWidth: widget.chatBubbleMaxWidth,
-            messageReactionConfig: messageConfig?.messageReactionConfig,
-            highlightColor: widget.highlightColor,
-            highlightMessage: widget.shouldHighlight,
-          );
-        } else if (widget.message.messageType.isVoice) {
-          return VoiceMessageView(
-            screenWidth: MediaQuery.of(context).size.width,
-            message: widget.message,
-            config: messageConfig?.voiceMessageConfig,
-            onMaxDuration: widget.onMaxDuration,
-            isMessageBySender: widget.isMessageBySender,
-            messageReactionConfig: messageConfig?.messageReactionConfig,
-            inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
-            outgoingChatBubbleConfig: widget.outgoingChatBubbleConfig,
-          );
-        } else if (widget.message.messageType.isCustom &&
-            messageConfig?.customMessageBuilder != null) {
-          return messageConfig?.customMessageBuilder!(widget.message);
-        }
-      }()),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          (() {
+                if (message.isAllEmoji) {
+                  return Stack(
+                    clipBehavior: Clip.none,
+                    children: [
+                      Padding(
+                        padding: emojiMessageConfiguration?.padding ??
+                            EdgeInsets.fromLTRB(
+                              leftPadding2,
+                              4,
+                              leftPadding2,
+                              widget.message.reaction.reactions.isNotEmpty
+                                  ? 14
+                                  : 0,
+                            ),
+                        child: Transform.scale(
+                          scale: widget.shouldHighlight
+                              ? widget.highlightScale
+                              : 1.0,
+                          child: Text(
+                            message,
+                            style: emojiMessageConfiguration?.textStyle ??
+                                const TextStyle(fontSize: 30),
+                          ),
+                        ),
+                      ),
+                      if (widget.message.reaction.reactions.isNotEmpty)
+                        ReactionWidget(
+                          reaction: widget.message.reaction,
+                          messageReactionConfig:
+                              messageConfig?.messageReactionConfig,
+                          isMessageBySender: widget.isMessageBySender,
+                        ),
+                    ],
+                  );
+                } else if (widget.message.messageType.isImage) {
+                  return ImageMessageView(
+                    message: widget.message,
+                    isMessageBySender: widget.isMessageBySender,
+                    imageMessageConfig: messageConfig?.imageMessageConfig,
+                    messageReactionConfig: messageConfig?.messageReactionConfig,
+                    highlightImage: widget.shouldHighlight,
+                    highlightScale: widget.highlightScale,
+                  );
+                } else if (widget.message.messageType.isText) {
+                  return TextMessageView(
+                    inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
+                    outgoingChatBubbleConfig: widget.outgoingChatBubbleConfig,
+                    isMessageBySender: widget.isMessageBySender,
+                    message: widget.message,
+                    chatBubbleMaxWidth: widget.chatBubbleMaxWidth,
+                    messageReactionConfig: messageConfig?.messageReactionConfig,
+                    highlightColor: widget.highlightColor,
+                    highlightMessage: widget.shouldHighlight,
+                  );
+                } else if (widget.message.messageType.isVoice) {
+                  return VoiceMessageView(
+                    screenWidth: MediaQuery.of(context).size.width,
+                    message: widget.message,
+                    config: messageConfig?.voiceMessageConfig,
+                    onMaxDuration: widget.onMaxDuration,
+                    isMessageBySender: widget.isMessageBySender,
+                    messageReactionConfig: messageConfig?.messageReactionConfig,
+                    inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
+                    outgoingChatBubbleConfig: widget.outgoingChatBubbleConfig,
+                  );
+                } else if (widget.message.messageType.isCustom &&
+                    messageConfig?.customMessageBuilder != null) {
+                  return messageConfig?.customMessageBuilder!(widget.message);
+                }
+              }()) ??
+              const SizedBox(),
+          ValueListenableBuilder(
+            valueListenable: widget.message.statusNotifier,
+            builder: (context, value, child) {
+              if (widget.isMessageBySender &&
+                  widget.controller?.initialMessageList.last.id ==
+                      widget.message.id &&
+                  widget.message.status == MessageStatus.read) {
+                if (widget
+                        .outgoingChatBubbleConfig
+                        ?.recieptsAndSendingNotifierWidgetConfiguration
+                        ?.messageSeenAgoRecieptVisible ??
+                    true) {
+                  return widget
+                          .outgoingChatBubbleConfig
+                          ?.recieptsAndSendingNotifierWidgetConfiguration
+                          ?.lastSeenAgoBuilder
+                          ?.call(
+                              widget.message,
+                              applicationDateFormatter(
+                                  widget.message.createdAt)) ??
+                      lastSeenAgoBuilder(widget.message,
+                          applicationDateFormatter(widget.message.createdAt));
+                }
+                return const SizedBox();
+              }
+              return const SizedBox();
+            },
+          )
+        ],
+      ),
     );
   }
 

--- a/lib/src/widgets/message_view.dart
+++ b/lib/src/widgets/message_view.dart
@@ -238,10 +238,10 @@ class _MessageViewState extends State<MessageView>
                   widget.controller?.initialMessageList.last.id ==
                       widget.message.id &&
                   widget.message.status == MessageStatus.read) {
-                if (widget.outgoingChatBubbleConfig?.recieptsWidgetConfig
+                if (widget.outgoingChatBubbleConfig?.receiptsWidgetConfig
                         ?.messageSeenAgoRecieptVisible ??
                     true) {
-                  return widget.outgoingChatBubbleConfig?.recieptsWidgetConfig
+                  return widget.outgoingChatBubbleConfig?.receiptsWidgetConfig
                           ?.lastSeenAgoBuilder
                           ?.call(
                               widget.message,

--- a/lib/src/widgets/profile_circle.dart
+++ b/lib/src/widgets/profile_circle.dart
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 import 'package:flutter/material.dart';
-import 'package:chatview/src/utils/constants.dart';
+import 'package:chatview/src/utils/constants/constants.dart';
 
 class ProfileCircle extends StatelessWidget {
   const ProfileCircle({

--- a/lib/src/widgets/reactions_bottomsheet.dart
+++ b/lib/src/widgets/reactions_bottomsheet.dart
@@ -1,6 +1,6 @@
 import 'package:chatview/src/controller/chat_controller.dart';
 import 'package:chatview/src/models/models.dart';
-import 'package:chatview/src/utils/constants.dart';
+import 'package:chatview/src/utils/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class ReactionsBottomSheet {

--- a/lib/src/widgets/reply_message_widget.dart
+++ b/lib/src/widgets/reply_message_widget.dart
@@ -26,7 +26,7 @@ import 'package:chatview/src/extensions/extensions.dart';
 import 'package:chatview/src/models/models.dart';
 import 'package:chatview/src/utils/package_strings.dart';
 
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 import 'chat_view_inherited_widget.dart';
 import 'vertical_line.dart';
 

--- a/lib/src/widgets/send_message_widget.dart
+++ b/lib/src/widgets/send_message_widget.dart
@@ -29,7 +29,7 @@ import 'package:chatview/chatview.dart';
 import 'package:chatview/src/extensions/extensions.dart';
 import 'package:chatview/src/utils/package_strings.dart';
 
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 
 class SendMessageWidget extends StatefulWidget {
   const SendMessageWidget({

--- a/lib/src/widgets/text_message_view.dart
+++ b/lib/src/widgets/text_message_view.dart
@@ -24,7 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:chatview/src/extensions/extensions.dart';
 import 'package:chatview/src/models/models.dart';
 
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 import 'link_preview.dart';
 import 'reaction_widget.dart';
 

--- a/lib/src/widgets/type_indicator_widget.dart
+++ b/lib/src/widgets/type_indicator_widget.dart
@@ -25,7 +25,7 @@ import 'package:flutter/material.dart';
 import 'package:chatview/src/widgets/profile_circle.dart';
 
 import '../../chatview.dart';
-import '../utils/constants.dart';
+import '../utils/constants/constants.dart';
 
 class TypingIndicator extends StatefulWidget {
   const TypingIndicator({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
   progress_indicators: ^1.0.0
   image_picker: ^0.8.6
   audio_waveforms: ^1.0.1
+  # For formatting time locale in message reciepts
+  timeago: ^3.4.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   progress_indicators: ^1.0.0
   image_picker: ^0.8.6
   audio_waveforms: ^1.0.1
-  stream_transform: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   progress_indicators: ^1.0.0
   image_picker: ^0.8.6
   audio_waveforms: ^1.0.1
+  stream_transform: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   progress_indicators: ^1.0.0
   image_picker: ^0.8.6
   audio_waveforms: ^1.0.1
-  # For formatting time locale in message reciepts
+  # For formatting time locale in message receipts
   timeago: ^3.4.0
 
 dev_dependencies:


### PR DESCRIPTION
# Rolling message receipts.

Complete customizable support for message receipts is what I have worked upon.


`WidgetReceiptsConfig` in `ChatBubble`  can be used to provide custom builders for message receipts a default implementation
is provided by default, for info you can visit to 18 paragraph in readme.md file also you can refer to the docs provided against each file.


**MessageStatus**

A new enum has been added  `MessageStatus` which corresponds to the current status of the message.

# MessageStatus
`MessageStatus` corresponds to the possible states a message can be in.

 ##  MessageStatus.pending
When a new message is created, its status defaults to `MessageStatus.pending`. A message in this status denotes that the message has not been sent yet.
This state persists when the network is flaky or somehow your backend implementation to send messages tackles some error.
 ##  MessageStatus.undelivered
This state must be set right after `MessageStatus.pending`, It denotes that the message has been successfully sent to another user.
 ##  MessageStatus.delivered
This state must be set right after `MessageStatus.undelivered`, It denotes that the message has been successfully sent and received by another user and you have got that message's delivery receipts/confirmation.
 ##  MessageStatus.read
This state must be set right after `MessageStatus.delivered`, It denotes that the message has been successfully sent, received, and read by another user and you have got that message's read receipts/confirmation.

# Receipts Builder
`receiptsBuilder` prop has been added to `ChatBubbleConfig` inside `WidgetReceiptsConfig` for building custom receipts.



## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Closes #75 
!-->

