### PR TITLE
fix: Replace deprecated 'showRecentsTab' with 'recentTabBehavior' in chatview package

### DIFF
--- a/lib/src/widgets/emoji_picker_widget.dart
+++ b/lib/src/widgets/emoji_picker_widget.dart
@@ -64,7 +64,7 @@ class EmojiPickerWidget extends StatelessWidget {
                 emojiSizeMax: 32 * ((!kIsWeb && Platform.isIOS) ? 1.30 : 1.0),
                 initCategory: Category.RECENT,
                 bgColor: Colors.white,
-                showRecentsTab: false,
+                recentTabBehavior: RecentTabBehavior.NONE,
                 recentsLimit: 28,
               ),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   intl: ^0.18.0
   flutter_linkify: ^5.0.2
   url_launcher: ^6.1.7
-  emoji_picker_flutter: ^1.3.0
+  emoji_picker_flutter: ^1.6.0
   http: ^0.13.5
   html: ^0.15.1
   any_link_preview: ^3.0.0


### PR DESCRIPTION
# Description
This PR addresses an issue that arose due to a breaking change in a dependency of the "chatview" package. The error message, "Could not build the precompiled application for the device. Error (Xcode): ../../.pub-cache/hosted/pub.dev/chatview-1.2.1/lib/src/widgets/emoji_picker_widget.dart:67:17: Error: No named parameter with the name 'showRecentsTab'." indicated the presence of the problem.

In the recent updates of the dependency, the 'showRecentsTab' property was deprecated, which caused the package to fail. This PR replaces the deprecated 'showRecentsTab' property with the new 'recentTabBehavior' property to resolve the issue. The motive behind this change is to keep the "chatview" package updated with the latest changes in its dependencies and to ensure seamless functionality.


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
This PR does not directly close any existing issues, but it does prevent potential future issues arising from the deprecated property.

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org