### PR TITLE
Allow to disable the text field and send buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ doc/api/
 .flutter-plugins
 /.flutter-plugins-dependencies
 chat_ui.iml
+
+# for those developers who use fvm not to upload the whole sdk
+.fvm/

--- a/lib/src/models/replied_message_configuration.dart
+++ b/lib/src/models/replied_message_configuration.dart
@@ -75,6 +75,10 @@ class RepliedMessageConfiguration {
   /// Color for microphone icon.
   final Color? micIconColor;
 
+  /// Customize what happens when user tap a reply message.
+  /// The default behaviour is to scroll to the message if [repliedMsgAutoScrollConfig] is enabled
+  final ReplyMessageCallBack? onReplyTapped;
+
   const RepliedMessageConfiguration({
     this.verticalBarColor,
     this.backgroundColor,
@@ -92,5 +96,6 @@ class RepliedMessageConfiguration {
     this.opacity,
     this.repliedMsgAutoScrollConfig = const RepliedMsgAutoScrollConfig(),
     this.micIconColor,
+    this.onReplyTapped,
   });
 }

--- a/lib/src/models/send_message_configuration.dart
+++ b/lib/src/models/send_message_configuration.dart
@@ -156,6 +156,11 @@ class TextFieldConfiguration {
   /// Default is 1 second.
   final Duration compositionThresholdTime;
 
+  /// Used for enable or disable the text field.
+  /// [false] also will disable the buttons for send images, record audio or take picture.
+  /// Default is [true].
+  final bool enabled;
+
   const TextFieldConfiguration({
     this.contentPadding,
     this.maxLines,
@@ -171,6 +176,7 @@ class TextFieldConfiguration {
     this.compositionThresholdTime = const Duration(seconds: 1),
     this.inputFormatters,
     this.textCapitalization,
+    this.enabled = true,
   });
 }
 

--- a/lib/src/widgets/chat_bubble_widget.dart
+++ b/lib/src/widgets/chat_bubble_widget.dart
@@ -309,15 +309,12 @@ class _ChatBubbleWidgetState extends State<ChatBubbleWidget> {
             ),
           ),
         if (replyMessage.isNotEmpty)
-          widget.repliedMessageConfig?.repliedMessageWidgetBuilder != null
-              ? widget.repliedMessageConfig!
-                  .repliedMessageWidgetBuilder!(widget.message.replyMessage)
-              : ReplyMessageWidget(
-                  message: widget.message,
-                  repliedMessageConfig: widget.repliedMessageConfig,
-                  onTap: () => widget.onReplyTap
-                      ?.call(widget.message.replyMessage.messageId),
-                ),
+          ReplyMessageWidget(
+            message: widget.message,
+            repliedMessageConfig: widget.repliedMessageConfig,
+            onTap: () =>
+                widget.onReplyTap?.call(widget.message.replyMessage.messageId),
+          ),
         MessageView(
           outgoingChatBubbleConfig:
               widget.chatBubbleConfig?.outgoingChatBubbleConfig,

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -193,7 +193,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                           const EdgeInsets.symmetric(horizontal: 6),
                       border: _outLineBorder,
                       focusedBorder: _outLineBorder,
+                      enabled: textFieldConfig?.enabled ?? true,
                       enabledBorder: OutlineInputBorder(
+                        borderSide: const BorderSide(color: Colors.transparent),
+                        borderRadius: textFieldConfig?.borderRadius ??
+                            BorderRadius.circular(textFieldBorderRadius),
+                      ),
+                      disabledBorder: OutlineInputBorder(
                         borderSide: const BorderSide(color: Colors.transparent),
                         borderRadius: textFieldConfig?.borderRadius ??
                             BorderRadius.circular(textFieldBorderRadius),
@@ -223,11 +229,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                               true)
                             IconButton(
                               constraints: const BoxConstraints(),
-                              onPressed: () => _onIconPressed(
-                                ImageSource.camera,
-                                config:
-                                    sendMessageConfig?.imagePickerConfiguration,
-                              ),
+                              onPressed: () => textFieldConfig?.enabled ?? true
+                                  ? _onIconPressed(
+                                      ImageSource.camera,
+                                      config: sendMessageConfig
+                                          ?.imagePickerConfiguration,
+                                    )
+                                  : null,
                               icon: imagePickerIconsConfig
                                       ?.cameraImagePickerIcon ??
                                   Icon(
@@ -240,11 +248,13 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                               true)
                             IconButton(
                               constraints: const BoxConstraints(),
-                              onPressed: () => _onIconPressed(
-                                ImageSource.gallery,
-                                config:
-                                    sendMessageConfig?.imagePickerConfiguration,
-                              ),
+                              onPressed: () => textFieldConfig?.enabled ?? true
+                                  ? _onIconPressed(
+                                      ImageSource.gallery,
+                                      config: sendMessageConfig
+                                          ?.imagePickerConfiguration,
+                                    )
+                                  : null,
                               icon: imagePickerIconsConfig
                                       ?.galleryImagePickerIcon ??
                                   Icon(
@@ -260,7 +270,9 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                                 Platform.isAndroid &&
                                 !kIsWeb)
                           IconButton(
-                            onPressed: _recordOrStop,
+                            onPressed: textFieldConfig?.enabled ?? true
+                                ? _recordOrStop
+                                : null,
                             icon: (isRecordingValue
                                     ? voiceRecordingConfig?.micIcon
                                     : voiceRecordingConfig?.stopIcon) ??

--- a/lib/src/widgets/reply_message_widget.dart
+++ b/lib/src/widgets/reply_message_widget.dart
@@ -50,6 +50,19 @@ class ReplyMessageWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (repliedMessageConfig?.repliedMessageWidgetBuilder != null) {
+      return GestureDetector(
+        onTap: () {
+          if (repliedMessageConfig!.onReplyTapped != null) {
+            repliedMessageConfig!.onReplyTapped!.call(message.replyMessage);
+          }
+          onTap?.call();
+        },
+        child: repliedMessageConfig!
+            .repliedMessageWidgetBuilder!(message.replyMessage),
+      );
+    }
+
     final currentUser = ChatViewInheritedWidget.of(context)?.currentUser;
     final replyBySender = message.replyMessage.replyBy == currentUser?.id;
     final textTheme = Theme.of(context).textTheme;
@@ -59,7 +72,12 @@ class ReplyMessageWidget extends StatelessWidget {
         chatController?.getUserFromId(message.replyMessage.replyBy);
     final replyBy = replyBySender ? PackageStrings.you : messagedUser?.name;
     return GestureDetector(
-      onTap: onTap,
+      onTap: () {
+        if (repliedMessageConfig!.onReplyTapped != null) {
+          repliedMessageConfig!.onReplyTapped!.call(message.replyMessage);
+        }
+        onTap?.call();
+      },
       child: Container(
         margin: repliedMessageConfig?.margin ??
             const EdgeInsets.only(


### PR DESCRIPTION
# Description

I'm developing a chat bot using the library. Every time the user makes a prompt I need to disable the field until the bot replies, I handle that by setting the `enable` variable to false.


## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality. 
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org