### PR TITLE
fix: Outdated intl dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   grouped_list: ^5.1.2
-  intl: ^0.18.0
+  intl: ^0.19.0
   flutter_linkify: ^6.0.0
   url_launcher: ^6.1.7
   emoji_picker_flutter: ^1.6.0


### PR DESCRIPTION
# Description
Since updating to flutter version 3.22.0, a lot of packages are now reliant on Intl 0.19.0. This PR updates chatview to 0.19.0


## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #145 
