### PR TITLE
fix: 🐛 correct usage of provide after unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
   to hide user name in chat.
 * **Fix**: [182](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/182) Fix
   send message not working when user start texting after newLine.
+* **Fix**: [191](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/pull/191) Fix
+  error when using `BuildContext` or `State` extensions when not mounted.
 
 ## [1.3.1]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,4 @@
 4.  Make sure your code lints.
 5.  Push your work back up to your fork.
 6.  Create the pull request!
+7.  Include the PR in the CHANGELOG.md

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -129,16 +129,18 @@ extension ChatViewStateTitleExtension on String? {
 
 /// Extension on State for accessing inherited widget.
 extension StatefulWidgetExtension on State {
-  ChatViewInheritedWidget? get provide => ChatViewInheritedWidget.of(context);
+  ChatViewInheritedWidget? get provide =>
+      mounted ? ChatViewInheritedWidget.of(context) : null;
 
   ReplySuggestionsConfig? get suggestionsConfig =>
-      SuggestionsConfigIW.of(context)?.suggestionsConfig;
+      mounted ? SuggestionsConfigIW.of(context)?.suggestionsConfig : null;
 }
 
 /// Extension on State for accessing inherited widget.
 extension BuildContextExtension on BuildContext {
-  ChatViewInheritedWidget? get provide => ChatViewInheritedWidget.of(this);
+  ChatViewInheritedWidget? get provide =>
+      mounted ? ChatViewInheritedWidget.of(this) : null;
 
   ReplySuggestionsConfig? get suggestionsConfig =>
-      SuggestionsConfigIW.of(this)?.suggestionsConfig;
+      mounted ? SuggestionsConfigIW.of(this)?.suggestionsConfig : null;
 }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->
When using `provide` I got some error messages that could all be prevented at the root by checking if the state is mounted.

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
#187 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org