### PR TITLE
🐛 fix: handle snackBar queue while reacting on message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   record cancelIcon is overflowed pixel
 * **Feat** [228](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/228) Ability to
   completely override userReactionCallback
+* **Fix**: [218](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/pull/218) fix: handle
+  snackBar queue while reacting on message
 
 ## [2.0.0]
 

--- a/lib/src/widgets/chat_list_widget.dart
+++ b/lib/src/widgets/chat_list_widget.dart
@@ -189,50 +189,50 @@ class _ChatListWidgetState extends State<ChatListWidget>
   }) {
     final replyPopup = chatListConfig.replyPopupConfig;
     ScaffoldMessenger.of(context)
-        .showSnackBar(
-          SnackBar(
-            duration: const Duration(hours: 1),
-            backgroundColor: replyPopup?.backgroundColor ?? Colors.white,
-            content: replyPopup?.replyPopupBuilder != null
-                ? replyPopup!.replyPopupBuilder!(message, sentByCurrentUser)
-                : ReplyPopupWidget(
-                    buttonTextStyle: replyPopup?.buttonTextStyle,
-                    topBorderColor: replyPopup?.topBorderColor,
-                    onMoreTap: () {
-                      _onChatListTap();
-                      replyPopup?.onMoreTap?.call(
-                        message,
-                        sentByCurrentUser,
-                      );
-                    },
-                    onReportTap: () {
-                      _onChatListTap();
-                      replyPopup?.onReportTap?.call(
-                        message,
-                      );
-                    },
-                    onUnsendTap: () {
-                      _onChatListTap();
-                      replyPopup?.onUnsendTap?.call(
-                        message,
-                      );
-                    },
-                    onReplyTap: () {
-                      widget.assignReplyMessage(message);
-                      if (featureActiveConfig?.enableReactionPopup ?? false) {
-                        chatViewIW?.showPopUp.value = false;
-                      }
-                      ScaffoldMessenger.of(context).hideCurrentSnackBar();
-                      if (replyPopup?.onReplyTap != null) {
-                        replyPopup?.onReplyTap!(message);
-                      }
-                    },
-                    sentByCurrentUser: sentByCurrentUser,
-                  ),
-            padding: EdgeInsets.zero,
-          ),
-        )
-        .closed;
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          duration: const Duration(hours: 1),
+          backgroundColor: replyPopup?.backgroundColor ?? Colors.white,
+          content: replyPopup?.replyPopupBuilder != null
+              ? replyPopup!.replyPopupBuilder!(message, sentByCurrentUser)
+              : ReplyPopupWidget(
+                  buttonTextStyle: replyPopup?.buttonTextStyle,
+                  topBorderColor: replyPopup?.topBorderColor,
+                  onMoreTap: () {
+                    _onChatListTap();
+                    replyPopup?.onMoreTap?.call(
+                      message,
+                      sentByCurrentUser,
+                    );
+                  },
+                  onReportTap: () {
+                    _onChatListTap();
+                    replyPopup?.onReportTap?.call(
+                      message,
+                    );
+                  },
+                  onUnsendTap: () {
+                    _onChatListTap();
+                    replyPopup?.onUnsendTap?.call(
+                      message,
+                    );
+                  },
+                  onReplyTap: () {
+                    widget.assignReplyMessage(message);
+                    if (featureActiveConfig?.enableReactionPopup ?? false) {
+                      chatViewIW?.showPopUp.value = false;
+                    }
+                    ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                    if (replyPopup?.onReplyTap != null) {
+                      replyPopup?.onReplyTap!(message);
+                    }
+                  },
+                  sentByCurrentUser: sentByCurrentUser,
+                ),
+          padding: EdgeInsets.zero,
+        ),
+      ).closed;
   }
 
   void _onChatListTap() {


### PR DESCRIPTION
- Fix if already snackBar is there then it open new snackBar on previous one.

# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org