### PR TITLE
🐛 fix: start and stop recording icons were reverse #226

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [2.0.1]
 
-* **Fix**: [217](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/pull/217) fixed y
+* **Fix**: [226](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/226) Fixed 
+  the icons for starting and stopping recording were reversed
+* **Fix**: [217](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/pull/217) Fixed y
   position of reaction popup
-* **Feat** [223](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/223) ability to
+* **Feat** [223](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/223) Ability to
   hide share icon in image view
 
 ## [2.0.0]

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -275,8 +275,8 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                                 ? _recordOrStop
                                 : null,
                             icon: (isRecordingValue
-                                    ? voiceRecordingConfig?.micIcon
-                                    : voiceRecordingConfig?.stopIcon) ??
+                                    ? voiceRecordingConfig?.stopIcon
+                                    : voiceRecordingConfig?.micIcon) ??
                                 Icon(
                                   isRecordingValue ? Icons.stop : Icons.mic,
                                   color:


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->
Closes #226 
<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org