### PR TITLE
feat: :sparkles: ability to completely override userReactionCallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   hide share icon in image view
 * **Fix**: [232](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/232) The audio
   record cancelIcon is overflowed pixel
+* **Feat** [228](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/228) Ability to
+  completely override userReactionCallback
 
 ## [2.0.0]
 

--- a/lib/src/models/reaction_popup_configuration.dart
+++ b/lib/src/models/reaction_popup_configuration.dart
@@ -54,8 +54,12 @@ class ReactionPopupConfiguration {
   /// Provides callback when user react on message.
   final ReactionCallback? userReactionCallback;
 
+  /// Provides feasibility to completely override userReactionCallback defaults to false.
+  final bool? overrideUserReactionCallback;
+
   const ReactionPopupConfiguration({
     this.userReactionCallback,
+    this.overrideUserReactionCallback = false,
     this.showGlassMorphismEffect = false,
     this.backgroundColor,
     this.shadow,

--- a/lib/src/widgets/reaction_popup.dart
+++ b/lib/src/widgets/reaction_popup.dart
@@ -147,11 +147,13 @@ class ReactionPopupState extends State<ReactionPopup>
         onEmojiTap: (emoji) {
           widget.onTap();
           if (currentUser != null && _message != null) {
-            chatController?.setReaction(
-              emoji: emoji,
-              messageId: _message!.id,
-              userId: currentUser!.id,
-            );
+            if (!(reactionPopupConfig?.overrideUserReactionCallback ?? false)) {
+              chatController?.setReaction(
+                emoji: emoji,
+                messageId: _message!.id,
+                userId: currentUser!.id,
+              );
+            }
             reactionPopupConfig?.userReactionCallback?.call(
               _message!,
               emoji,


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

Fixes #228 

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org