### PR TITLE
fix: 🐛 Padding `chatTextFieldViewKey` key gets re-initialized every widget render

### DIFF
--- a/lib/src/widgets/chat_groupedlist_widget.dart
+++ b/lib/src/widgets/chat_groupedlist_widget.dart
@@ -21,6 +21,7 @@
  */
 import 'package:chatview/chatview.dart';
 import 'package:chatview/src/extensions/extensions.dart';
+import 'package:chatview/src/widgets/chat_view_inherited_widget.dart';
 import 'package:chatview/src/widgets/suggestions/suggestion_list.dart';
 import 'package:chatview/src/widgets/type_indicator_widget.dart';
 import 'package:flutter/material.dart';
@@ -105,7 +106,7 @@ class _ChatGroupedListWidgetState extends State<ChatGroupedListWidget>
       if (!mounted) return;
       setState(() {
         chatTextFieldHeight =
-            chatViewIW?.chatTextFieldViewKey.currentContext?.size?.height ?? 10;
+            ChatViewInheritedWidget.chatTextFieldViewKey.currentContext?.size?.height ?? 10;
       });
     });
   }

--- a/lib/src/widgets/chat_view_inherited_widget.dart
+++ b/lib/src/widgets/chat_view_inherited_widget.dart
@@ -15,7 +15,7 @@ class ChatViewInheritedWidget extends InheritedWidget {
   final FeatureActiveConfig featureActiveConfig;
   final ProfileCircleConfiguration? profileCircleConfiguration;
   final ChatController chatController;
-  final GlobalKey chatTextFieldViewKey = GlobalKey();
+  static final GlobalKey chatTextFieldViewKey = GlobalKey();
   final ValueNotifier<bool> showPopUp = ValueNotifier(false);
   final GlobalKey<ReactionPopupState> reactionPopupKey = GlobalKey();
 

--- a/lib/src/widgets/send_message_widget.dart
+++ b/lib/src/widgets/send_message_widget.dart
@@ -24,6 +24,7 @@ import 'dart:io' if (kIsWeb) 'dart:html';
 import 'package:chatview/chatview.dart';
 import 'package:chatview/src/extensions/extensions.dart';
 import 'package:chatview/src/utils/package_strings.dart';
+import 'package:chatview/src/widgets/chat_view_inherited_widget.dart';
 import 'package:chatview/src/widgets/chatui_textfield.dart';
 import 'package:chatview/src/widgets/reply_message_view.dart';
 import 'package:chatview/src/widgets/scroll_to_bottom_button.dart';
@@ -143,7 +144,7 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
                             ),
                           ),
                         Padding(
-                          key: chatViewIW?.chatTextFieldViewKey,
+                          key: ChatViewInheritedWidget.chatTextFieldViewKey,
                           padding: EdgeInsets.fromLTRB(
                             bottomPadding4,
                             bottomPadding4,


### PR DESCRIPTION
# Description
This proposed PR aims to fix #216 and #253.

**Before changes**
In `lib/src/widgets/send_message_widget.dart` (line 147), the widget gets re-rendered every time there are any state changes (e.g: screen resizing due to keyboard avoiding behavior in iOS) in the widget due to the `chatTextFieldViewKey` key re-initialization of the `Padding` widget. See video below:

https://github.com/user-attachments/assets/efc63716-5923-4663-a088-edaa6c9c15d4

**After changes**
This PR makes the `chatTextFieldViewKey` to be initialized only once (singleton design pattern-like), even after widget state changes. This prevents unnecessary re-render.

https://github.com/user-attachments/assets/d2a5c1ce-f08d-4aa0-a45b-6eb91e20066e

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #216 and #253 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org