### PR TITLE
feat: Add a custom reaction popup and some fixes

### DIFF
--- a/lib/src/models/config_models/reaction_popup_configuration.dart
+++ b/lib/src/models/config_models/reaction_popup_configuration.dart
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:chatview/src/models/data_models/message.dart';
 import 'package:flutter/material.dart';
 
 import '../../values/typedefs.dart';
@@ -42,6 +43,9 @@ class ReactionPopupConfiguration {
   /// Used for give padding in reaction pop-up.
   final EdgeInsetsGeometry? padding;
 
+  /// Used for give borderRadius in reaction pop-up.
+  final BorderRadius? borderRadius;
+
   /// Provides emoji configuration in reaction pop-up.
   final EmojiConfiguration? emojiConfig;
 
@@ -57,6 +61,9 @@ class ReactionPopupConfiguration {
   /// Provides feasibility to completely override userReactionCallback defaults to false.
   final bool? overrideUserReactionCallback;
 
+  /// Provides a custom popup to use instead of emojis
+  final Widget Function(Message? message)? customReactionPopup;
+
   const ReactionPopupConfiguration({
     this.userReactionCallback,
     this.overrideUserReactionCallback = false,
@@ -67,8 +74,10 @@ class ReactionPopupConfiguration {
     this.maxWidth,
     this.margin,
     this.padding,
+    this.borderRadius,
     this.emojiConfig,
     this.glassMorphismConfig,
+    this.customReactionPopup,
   });
 }
 

--- a/lib/src/models/config_models/send_message_configuration.dart
+++ b/lib/src/models/config_models/send_message_configuration.dart
@@ -158,6 +158,9 @@ class TextFieldConfiguration {
   /// Callback when a user starts/stops typing a message by [TypeWriterStatus]
   final void Function(TypeWriterStatus status)? onMessageTyping;
 
+  /// Callback when a user submits a message
+  final StringMessageCallBack? onMessageSubmit;
+
   /// After typing stopped, the threshold time after which the composing
   /// status to be changed to [TypeWriterStatus.composed].
   /// Default is 1 second.
@@ -167,6 +170,10 @@ class TextFieldConfiguration {
   /// [false] also will disable the buttons for send images, record audio or take picture.
   /// Default is [true].
   final bool enabled;
+
+  /// Used for autofocus of the text field.
+  /// Default is [false].
+  final bool autofocus;
 
   const TextFieldConfiguration({
     this.contentPadding,
@@ -183,7 +190,9 @@ class TextFieldConfiguration {
     this.compositionThresholdTime = const Duration(seconds: 1),
     this.inputFormatters,
     this.textCapitalization,
+    this.onMessageSubmit,
     this.enabled = true,
+    this.autofocus = false,
   });
 }
 

--- a/lib/src/widgets/chat_view.dart
+++ b/lib/src/widgets/chat_view.dart
@@ -199,42 +199,41 @@ class _ChatViewState extends State<ChatView>
       child: SuggestionsConfigIW(
         suggestionsConfig: widget.replySuggestionsConfig,
         child: Builder(builder: (context) {
-          return Stack(
-            children: [
-              Container(
-                height: chatBackgroundConfig.height ??
-                    MediaQuery.of(context).size.height,
-                width: chatBackgroundConfig.width ??
-                    MediaQuery.of(context).size.width,
-                decoration: BoxDecoration(
-                  color: chatBackgroundConfig.backgroundColor ?? Colors.white,
-                  image: chatBackgroundConfig.backgroundImage != null
-                      ? DecorationImage(
-                          fit: BoxFit.fill,
-                          image: NetworkImage(
-                              chatBackgroundConfig.backgroundImage!),
-                        )
-                      : null,
-                ),
-                padding: chatBackgroundConfig.padding,
-                margin: chatBackgroundConfig.margin,
-                child: Column(
-                  children: [
-                    if (widget.appBar != null) widget.appBar!,
-                    Expanded(
-                      child: ConfigurationsInheritedWidget(
-                        chatBackgroundConfig: widget.chatBackgroundConfig,
-                        reactionPopupConfig: widget.reactionPopupConfig,
-                        typeIndicatorConfig: widget.typeIndicatorConfig,
-                        chatBubbleConfig: widget.chatBubbleConfig,
-                        replyPopupConfig: widget.replyPopupConfig,
-                        messageConfig: widget.messageConfig,
-                        profileCircleConfig: widget.profileCircleConfig,
-                        repliedMessageConfig: widget.repliedMessageConfig,
-                        swipeToReplyConfig: widget.swipeToReplyConfig,
-                        emojiPickerSheetConfig: widget.emojiPickerSheetConfig,
-                        scrollToBottomButtonConfig:
-                            widget.scrollToBottomButtonConfig,
+          return ConfigurationsInheritedWidget(
+            chatBackgroundConfig: widget.chatBackgroundConfig,
+            reactionPopupConfig: widget.reactionPopupConfig,
+            typeIndicatorConfig: widget.typeIndicatorConfig,
+            chatBubbleConfig: widget.chatBubbleConfig,
+            replyPopupConfig: widget.replyPopupConfig,
+            messageConfig: widget.messageConfig,
+            profileCircleConfig: widget.profileCircleConfig,
+            repliedMessageConfig: widget.repliedMessageConfig,
+            swipeToReplyConfig: widget.swipeToReplyConfig,
+            emojiPickerSheetConfig: widget.emojiPickerSheetConfig,
+            scrollToBottomButtonConfig: widget.scrollToBottomButtonConfig,
+            child: Stack(
+              children: [
+                Container(
+                  height: chatBackgroundConfig.height ??
+                      MediaQuery.of(context).size.height,
+                  width: chatBackgroundConfig.width ??
+                      MediaQuery.of(context).size.width,
+                  decoration: BoxDecoration(
+                    color: chatBackgroundConfig.backgroundColor ?? Colors.white,
+                    image: chatBackgroundConfig.backgroundImage != null
+                        ? DecorationImage(
+                            fit: BoxFit.fill,
+                            image: NetworkImage(
+                                chatBackgroundConfig.backgroundImage!),
+                          )
+                        : null,
+                  ),
+                  padding: chatBackgroundConfig.padding,
+                  margin: chatBackgroundConfig.margin,
+                  child: Column(
+                    children: [
+                      if (widget.appBar != null) widget.appBar!,
+                      Expanded(
                         child: Stack(
                           children: [
                             if (chatViewState.isLoading)
@@ -301,22 +300,22 @@ class _ChatViewState extends State<ChatView>
                           ],
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              if (featureActiveConfig.enableReactionPopup)
-                ValueListenableBuilder<bool>(
-                  valueListenable: context.chatViewIW!.showPopUp,
-                  builder: (_, showPopupValue, child) {
-                    return ReactionPopup(
-                      key: context.chatViewIW!.reactionPopupKey,
-                      onTap: () => _onChatListTap(context),
-                      showPopUp: showPopupValue,
-                    );
-                  },
-                ),
-            ],
+                if (featureActiveConfig.enableReactionPopup)
+                  ValueListenableBuilder<bool>(
+                    valueListenable: context.chatViewIW!.showPopUp,
+                    builder: (_, showPopupValue, child) {
+                      return ReactionPopup(
+                        key: context.chatViewIW!.reactionPopupKey,
+                        onTap: () => _onChatListTap(context),
+                        showPopUp: showPopupValue,
+                      );
+                    },
+                  ),
+              ],
+            ),
           );
         }),
       ),

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -39,6 +39,7 @@ class ChatUITextField extends StatefulWidget {
     required this.focusNode,
     required this.textEditingController,
     required this.onPressed,
+    required this.onSubmit,
     required this.onRecordingComplete,
     required this.onImageSelected,
   }) : super(key: key);
@@ -54,6 +55,9 @@ class ChatUITextField extends StatefulWidget {
 
   /// Provides callback when user tap on text field.
   final VoidCallBack onPressed;
+
+  /// Provides callback when user submitted text field.
+  final VoidCallBack onSubmit;
 
   /// Provides callback once voice is recorded.
   final Function(String?) onRecordingComplete;
@@ -182,6 +186,10 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                     keyboardType: textFieldConfig?.textInputType,
                     inputFormatters: textFieldConfig?.inputFormatters,
                     onChanged: _onChanged,
+                    onSubmitted: (_) {
+                      widget.onSubmit();
+                    },
+                    autofocus: textFieldConfig?.autofocus ?? false,
                     enabled: textFieldConfig?.enabled,
                     textCapitalization: textFieldConfig?.textCapitalization ??
                         TextCapitalization.sentences,

--- a/lib/src/widgets/reaction_popup.dart
+++ b/lib/src/widgets/reaction_popup.dart
@@ -123,7 +123,8 @@ class ReactionPopupState extends State<ReactionPopup>
                           decoration: BoxDecoration(
                             color: reactionPopupConfig?.backgroundColor ??
                                 Colors.white,
-                            borderRadius: BorderRadius.circular(30),
+                            borderRadius: reactionPopupConfig?.borderRadius ??
+                                BorderRadius.circular(30),
                             boxShadow: [
                               reactionPopupConfig?.shadow ??
                                   BoxShadow(
@@ -143,24 +144,35 @@ class ReactionPopupState extends State<ReactionPopup>
         : const SizedBox.shrink();
   }
 
-  Widget get _reactionPopupRow => EmojiRow(
-        onEmojiTap: (emoji) {
-          widget.onTap();
-          if (currentUser != null && _message != null) {
-            if (!(reactionPopupConfig?.overrideUserReactionCallback ?? false)) {
-              chatController?.setReaction(
-                emoji: emoji,
-                messageId: _message!.id,
-                userId: currentUser!.id,
-              );
-            }
-            reactionPopupConfig?.userReactionCallback?.call(
-              _message!,
-              emoji,
+  Widget get _reactionPopupRow =>
+      reactionPopupConfig?.customReactionPopup != null
+          ? Listener(
+              onPointerUp: (_) {
+                widget.onTap();
+                reactionPopupConfig?.userReactionCallback?.call(_message!, '');
+              },
+              child: reactionPopupConfig?.customReactionPopup?.call(_message) ??
+                  const SizedBox.shrink(),
+            )
+          : EmojiRow(
+              onEmojiTap: (emoji) {
+                widget.onTap();
+                if (currentUser != null && _message != null) {
+                  if (!(reactionPopupConfig?.overrideUserReactionCallback ??
+                      false)) {
+                    chatController?.setReaction(
+                      emoji: emoji,
+                      messageId: _message!.id,
+                      userId: currentUser!.id,
+                    );
+                  }
+                  reactionPopupConfig?.userReactionCallback?.call(
+                    _message!,
+                    emoji,
+                  );
+                }
+              },
             );
-          }
-        },
-      );
 
   void refreshWidget({
     required Message message,

--- a/lib/src/widgets/send_message_widget.dart
+++ b/lib/src/widgets/send_message_widget.dart
@@ -260,6 +260,7 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
                                 focusNode: _focusNode,
                                 textEditingController: _textEditingController,
                                 onPressed: _onPressed,
+                                onSubmit: _onPressed,
                                 sendMessageConfig: widget.sendMessageConfig,
                                 onRecordingComplete: _onRecordingComplete,
                                 onImageSelected: _onImageSelected,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chatview
 description: A Flutter package that allows you to integrate Chat View with highly customization options.
-version: 2.2.0
+version: 2.2.1
 issue_tracker: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues
 repository: https://github.com/SimformSolutionsPvtLtd/flutter_chatview
 


### PR DESCRIPTION
# Description
Added the possibility to specify a `customReactionPopup`. This can be used instead of emojis when long pressing on a message, for example it can be used to show a menu. It also returns the message which was pressed.
I used `Listener`, so both `widget.onTap` and also external taps can be handled from `customReactionPopup`.

Added also possibility to set the `borderRadius` for the popup.

Added possibility to set `autofocus` for the text field. Default is false.

Fixed issue with trying to submit a message by pressing enter in the keyboard, now `onSubmit` calls `_onPressed`, sending the message.

Fixed issue with the reaction popup config, `ConfigurationsInheritedWidget` had to be moved up to contain also the `ReactionPopup`, this way the config here won't be null anymore and all reaction popup configs will work, see #261 


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
Closes #261 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org