### PR TITLE
🐛 add error message for link preview parse error #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UnReleased] 
+
+* **Fix**: [276](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/276) link preview custom error message
+
 ## [2.3.0]
 
 * **Breaking**: [257](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/257) update

--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,20 @@ ChatView(
 ),
 ```
 
+
+36. Use `errorBody` to displays an error message when the link cannot be parsed for preview.
+
+
+```dart
+ChatView(
+  ...
+    linkPreviewConfig: LinkPreviewConfiguration(
+      errorBody: 'Error encountered while parsing the link for preview'
+),
+  ...
+),
+```
+
 ## How to use
 
 Check out [blog](https://medium.com/simform-engineering/chatview-a-cutting-edge-chat-ui-solution-7367b1f9d772) for better understanding and basic implementation.

--- a/lib/src/models/config_models/link_preview_configuration.dart
+++ b/lib/src/models/config_models/link_preview_configuration.dart
@@ -50,6 +50,9 @@ class LinkPreviewConfiguration {
   /// Provides callback when message detect url in message.
   final StringCallback? onUrlDetect;
 
+  /// Displays an error message when the link cannot be parsed for preview.
+  final String? errorBody;
+
   const LinkPreviewConfiguration({
     this.onUrlDetect,
     this.loadingColor,
@@ -60,5 +63,6 @@ class LinkPreviewConfiguration {
     this.linkStyle,
     this.padding,
     this.proxyUrl,
+    this.errorBody,
   });
 }

--- a/lib/src/widgets/link_preview.dart
+++ b/lib/src/widgets/link_preview.dart
@@ -64,6 +64,7 @@ class LinkPreview extends StatelessWidget {
                 : AnyLinkPreview(
                     link: url,
                     removeElevation: true,
+                    errorBody: linkPreviewConfig?.errorBody,
                     proxyUrl: linkPreviewConfig?.proxyUrl,
                     onTap: _onLinkTap,
                     placeholderWidget: SizedBox(


### PR DESCRIPTION
# Description
- Added a new field to the LinkPreviewConfiguration that provides an error message when the link is not suitable for generating a preview.
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [X] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [X] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [X] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [X] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [ ] Yes, this PR is a breaking change.
- [X] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #276 
!-->
Closes #276 

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org