### PR TITLE
feat: 🤖 Introduced animated typewriter functionality, allowing developers to seamlessly integrate the chat view for chatbot implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.5.0]
+
+* **Feat**: [309](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/309) Introduced animated typewriter functionality, allowing developers to seamlessly integrate the chat view for chatbot implementations.
+
 ## [2.4.0]
 
 * **Feat**: [251](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/251) Add

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -65,6 +65,11 @@ class _ChatScreenState extends State<ChatScreen> {
         profilePhoto: Data.profileImage,
       ),
     ],
+
+    ///Uncomment to enable typewriter functionality
+    // typewriterAnimatedConfiguration: TypewriterAnimatedConfiguration(
+    //   enableConfiguration: true,
+    // ),
   );
 
   void _showHideTypingIndicator() {

--- a/lib/src/controller/chat_controller.dart
+++ b/lib/src/controller/chat_controller.dart
@@ -21,6 +21,7 @@
  */
 import 'dart:async';
 
+import 'package:chatview/src/models/config_models/typing_configuration.dart';
 import 'package:chatview/src/widgets/suggestions/suggestion_list.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -74,12 +75,17 @@ class ChatController {
   /// Provides current user which is sending messages.
   final ChatUser currentUser;
 
+  ///Configuration for Animated Typewriter functionality as in a chatbot.
+  TypewriterAnimatedConfiguration typewriterAnimatedConfiguration;
+
   ChatController({
     required this.initialMessageList,
     required this.scrollController,
     required this.otherUsers,
     required this.currentUser,
-  });
+    TypewriterAnimatedConfiguration? typewriterAnimatedConfiguration,
+  }) : typewriterAnimatedConfiguration = typewriterAnimatedConfiguration ??
+            TypewriterAnimatedConfiguration();
 
   /// Represents message stream of chat
   StreamController<List<Message>> messageStreamController = StreamController();

--- a/lib/src/models/config_models/typing_configuration.dart
+++ b/lib/src/models/config_models/typing_configuration.dart
@@ -20,22 +20,30 @@
  * SOFTWARE.
  */
 
-library chatview;
+import 'package:animated_text_kit/animated_text_kit.dart';
 
-export 'src/widgets/chat_view.dart';
-export 'src/models/models.dart';
-export 'src/widgets/chat_view_appbar.dart';
-export 'src/values/enumeration.dart';
-export 'src/controller/chat_controller.dart';
-export 'src/values/typedefs.dart';
-export 'package:audio_waveforms/audio_waveforms.dart'
-    show
-        WaveStyle,
-        PlayerWaveStyle,
-        AndroidEncoder,
-        IosEncoder,
-        AndroidOutputFormat;
-export 'src/models/config_models/receipts_widget_config.dart';
-export 'src/extensions/extensions.dart' show MessageTypes;
-export 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
-export '/src/models/config_models/typing_configuration.dart';
+///Configuration for Animated Typewriter functionality as in a chatbot.
+class TypewriterAnimatedConfiguration {
+  ///Toggle to enable
+  /// By default it is set to false.
+  final bool enableConfiguration;
+
+  /// A controller for managing the state of an animated text sequence.
+  ///
+  /// This controller exposes methods to play, pause, and reset the animation.
+  /// The [AnimatedTextState] enum represents the various states the animation
+  /// can be in. By calling [play()], [pause()], or [reset()], you can transition
+  /// between these states and the animated widget will react accordingly.
+  AnimatedTextController? controller;
+
+  /// Should the animation ends up early and display full text if you tap on it?
+  ///
+  /// By default it is set to false.
+  final bool displayFullTextOnTap;
+
+  TypewriterAnimatedConfiguration({
+    this.displayFullTextOnTap = false,
+    this.controller,
+    this.enableConfiguration = false,
+  });
+}

--- a/lib/src/widgets/text_message_view.dart
+++ b/lib/src/widgets/text_message_view.dart
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 import 'package:animated_text_kit/animated_text_kit.dart';
+import 'package:chatview/src/widgets/chat_view_inherited_widget.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chatview/src/extensions/extensions.dart';
@@ -70,6 +71,7 @@ class TextMessageView extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     final textMessage = message.message;
+    final chatController = ChatViewInheritedWidget.of(context)!.chatController;
     return Stack(
       clipBehavior: Clip.none,
       children: [
@@ -94,7 +96,10 @@ class TextMessageView extends StatelessWidget {
                   linkPreviewConfig: _linkPreviewConfig,
                   url: textMessage,
                 )
-              : !isMessageBySender
+              : !isMessageBySender &&
+                      chatController.typewriterAnimatedConfiguration
+                          .enableConfiguration &&
+                      chatController.initialMessageList.isNotEmpty
                   ? AnimatedTextKit(
                       animatedTexts: [
                         TypewriterAnimatedText(
@@ -107,11 +112,11 @@ class TextMessageView extends StatelessWidget {
                           speed: const Duration(milliseconds: 50),
                         ),
                       ],
-                      totalRepeatCount: 0, isRepeatingAnimation: false,
-                      pause: const Duration(milliseconds: 1000),
-                      displayFullTextOnTap: true,
-                      stopPauseOnTap: false,
-                      // controller: myAnimatedTextController,
+                      isRepeatingAnimation: false,
+                      displayFullTextOnTap: chatController
+                          .typewriterAnimatedConfiguration.displayFullTextOnTap,
+                      controller: chatController
+                          .typewriterAnimatedConfiguration.controller,
                     )
                   : Text(
                       textMessage,

--- a/lib/src/widgets/text_message_view.dart
+++ b/lib/src/widgets/text_message_view.dart
@@ -19,6 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import 'package:animated_text_kit/animated_text_kit.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chatview/src/extensions/extensions.dart';
@@ -93,14 +94,33 @@ class TextMessageView extends StatelessWidget {
                   linkPreviewConfig: _linkPreviewConfig,
                   url: textMessage,
                 )
-              : Text(
-                  textMessage,
-                  style: _textStyle ??
-                      textTheme.bodyMedium!.copyWith(
-                        color: Colors.white,
-                        fontSize: 16,
-                      ),
-                ),
+              : !isMessageBySender
+                  ? AnimatedTextKit(
+                      animatedTexts: [
+                        TypewriterAnimatedText(
+                          textMessage,
+                          textStyle: _textStyle ??
+                              textTheme.bodyMedium!.copyWith(
+                                color: Colors.white,
+                                fontSize: 16,
+                              ),
+                          speed: const Duration(milliseconds: 50),
+                        ),
+                      ],
+                      totalRepeatCount: 0, isRepeatingAnimation: false,
+                      pause: const Duration(milliseconds: 1000),
+                      displayFullTextOnTap: true,
+                      stopPauseOnTap: false,
+                      // controller: myAnimatedTextController,
+                    )
+                  : Text(
+                      textMessage,
+                      style: _textStyle ??
+                          textTheme.bodyMedium!.copyWith(
+                            color: Colors.white,
+                            fontSize: 16,
+                          ),
+                    ),
         ),
         if (message.reaction.reactions.isNotEmpty)
           ReactionWidget(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   audio_waveforms: ^1.2.0
   # For formatting time locale in message receipts
   cached_network_image: ^3.4.1
+  animated_text_kit: ^4.2.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: chatview
 description: A Flutter package that allows you to integrate Chat View with highly customization options.
-version: 2.4.0
+version: 2.5.0
 issue_tracker: https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues
 repository: https://github.com/SimformSolutionsPvtLtd/flutter_chatview
 


### PR DESCRIPTION
# Description
This PR introduces an animated typewriter effect for chat responses, similar to the animation seen in ChatGPT. The typewriter effect is applied exclusively to responses from the other user, ensuring a natural flow of dialogue. This feature was added to enhance the user experience for a chatbot I was working on. To implement this, I utilized the `animated_text_kit` package. 
There are no breaking changes or modifications to existing APIs—this functionality simply enhances the current behavior without altering any core logic.


- [ x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ x] I have updated/added relevant examples in `examples` or `docs`.


- [ ] Yes, this PR is a breaking change.
- [ x] No, this PR is not a breaking change.
