### PR TITLE
fix: ScrollController is disposed when parent widget state changes (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [2.4.1] (unreleased)
 
+* **Fix**: [289](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/289)
+  ScrollController is disposed when parent widget state changes
 * **Fix**: [317](https://github.com/SimformSolutionsPvtLtd/flutter_chatview/issues/317) Link Preview
   is attempted even after adding disableLinkPreview: true
 

--- a/lib/src/widgets/chat_list_widget.dart
+++ b/lib/src/widgets/chat_list_widget.dart
@@ -246,8 +246,6 @@ class _ChatListWidgetState extends State<ChatListWidget>
 
   @override
   void dispose() {
-    chatController.messageStreamController.close();
-    scrollController.dispose();
     _isNextPageLoading.dispose();
     super.dispose();
   }


### PR DESCRIPTION
# Description

This PR fixes a lifecycle issue where `ChatListWidget` improperly disposes the `ScrollController` provided via the external `ChatController`.

Currently, `ChatController.scrollController` is passed into the widget tree and used in multiple places, including pagination and scrolling logic. However, the `ChatListWidget` calls `scrollController.dispose()` in its `dispose()` method — even though it did not create the controller.

This causes runtime exceptions (`ScrollController was disposed`) when parent widgets rebuild and reuse the same controller, which is a valid and supported use case.

### This PR changes:

* Removes the call to `scrollController.dispose()` and `chatController.messageStreamController.close()` from `ChatListWidget.dispose()`
* Ensures that the responsibility of disposing shared resources remains with the owning class (i.e., `ChatController`)

No behavior changes, just safer lifecycle management.

## Checklist

* [x] The title of my PR starts with a \[Conventional Commit] prefix (`fix:`).
* [x] I have followed the \[Contributor Guide] when preparing my PR.
* [ ] I have updated/added tests for ALL new/updated/fixed functionality.
* [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
* [ ] I have updated/added relevant examples in `examples` or `docs`.

> (Tests/docs not updated because the fix affects lifecycle behavior, not exposed API.)

## Breaking Change?

* [ ] Yes, this PR is a breaking change.
* [x] No, this PR is not a breaking change.

## Related Issues

N/A, but may be related to general lifecycle issues encountered by users embedding `ChatView` in reactive widget trees (e.g. GetX, Riverpod).
