### PR TITLE
feat: ✨ File message type and trailing parameter (for custom file i…

### DIFF
--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -118,6 +118,8 @@ extension MessageTypes on MessageType {
   bool get isVoice => this == MessageType.voice;
 
   bool get isCustom => this == MessageType.custom;
+
+  bool get isFile => this == MessageType.file; 
 }
 
 /// Extension on ConnectionState for checking specific connection.

--- a/lib/src/models/config_models/send_message_configuration.dart
+++ b/lib/src/models/config_models/send_message_configuration.dart
@@ -54,6 +54,7 @@ class SendMessageConfiguration {
     this.selectedImageViewHeight,
     this.imageBorderRadius,
     this.selectedImageViewBuilder,
+    this.trailing, // <--- ADDED THIS LINE
   });
 
   /// Used to give background color to text field.
@@ -127,6 +128,10 @@ class SendMessageConfiguration {
 
   /// Provides ability to build custom view for selected images in text field.
   final SelectedImageViewBuilder? selectedImageViewBuilder;
+
+  /// Provides list of widgets that will be placed at the trailing end
+  /// of the text input field, typically used for custom action buttons.
+  final List<Widget>? trailing; // <--- ADDED THIS FIELD
 }
 
 class ImagePickerIconsConfiguration {
@@ -245,7 +250,7 @@ class ImagePickerConfiguration {
   final CameraDevice? preferredCameraDevice;
 
   /// Callback when image is picked from camera or gallery,
-  ///  we can perform our task on image like adding crop options and return new image path
+  ///  we can perform our task on image like adding crop options and return new image path
   final ImagePickedCallback? onImagePicked;
 }
 

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -84,6 +84,7 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
   VoiceRecordingConfiguration? get voiceRecordingConfig =>
       widget.sendMessageConfig?.voiceRecordingConfiguration;
 
+  // FIX: Corrected getter name from imagePickerIconsConfiguration to imagePickerIconsConfig
   ImagePickerIconsConfiguration? get imagePickerIconsConfig =>
       sendMessageConfig?.imagePickerIconsConfig;
 
@@ -283,7 +284,7 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                       children: [
                         if (!isRecordingValue) ...[
                           if (sendMessageConfig?.enableCameraImagePicker ??
-                              true)
+                                  true)
                             IconButton(
                               constraints: const BoxConstraints(),
                               onPressed: (textFieldConfig?.enabled ?? true)
@@ -302,7 +303,7 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                                   ),
                             ),
                           if (sendMessageConfig?.enableGalleryImagePicker ??
-                              true)
+                                  true)
                             IconButton(
                               constraints: const BoxConstraints(),
                               onPressed: (textFieldConfig?.enabled ?? true)
@@ -349,6 +350,8 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                             color: cancelRecordConfiguration?.iconColor ??
                                 voiceRecordingConfig?.recorderIconColor,
                           ),
+                        if (sendMessageConfig?.trailing != null)
+                          ...sendMessageConfig!.trailing!,
                       ],
                     );
                   }

--- a/lib/src/widgets/file_message_view.dart
+++ b/lib/src/widgets/file_message_view.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/material.dart';
+import 'dart:io'; // Needed for File class
+import 'package:chatview_utils/chatview_utils.dart'; // For Message model
+import 'package:open_filex/open_filex.dart'; // Import open_filex
+import 'package:url_launcher/url_launcher.dart'; // Import url_launcher
+import 'package:flutter/foundation.dart' show kIsWeb; // Import kIsWeb
+
+class FileMessageView extends StatelessWidget {
+  const FileMessageView({
+    Key? key,
+    required this.message,
+    required this.isMessageBySender,
+  }) : super(key: key);
+
+  final Message message;
+  final bool isMessageBySender;
+
+  // Function to check if a string is a valid HTTP/HTTPS URL
+  bool _isWebUrl(String urlString) {
+    try {
+      final uri = Uri.parse(urlString);
+      return uri.scheme == 'http' || uri.scheme == 'https';
+    } catch (e) {
+      return false;
+    }
+  }
+
+  void _onFileTap(BuildContext context, String pathOrUrl) async {
+    print('--- File Tap Debug Start ---');
+    print('1. Input path/URL: $pathOrUrl');
+
+    if (kIsWeb) {
+      // On web, always try to open as a URL
+      try {
+        final uri = Uri.parse(pathOrUrl);
+        if (await canLaunchUrl(uri)) {
+          await launchUrl(uri, mode: LaunchMode.platformDefault);
+          print('Opened URL on Web: $pathOrUrl');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Opened web link: ${uri.host}')),
+          );
+        } else {
+          print('Could not launch URL on Web: $pathOrUrl');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not open web link.')),
+          );
+        }
+      } catch (e) {
+        print('Error parsing or launching URL on Web: $e');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Invalid URL or error opening: $pathOrUrl')),
+        );
+      }
+      print('--- File Tap Debug End (Web) ---');
+      return; // Exit as web handling is done
+    }
+
+    // For non-web platforms (mobile, desktop)
+    if (_isWebUrl(pathOrUrl)) {
+      print('2. Detected as Web URL. Attempting to open with url_launcher.');
+      try {
+        final uri = Uri.parse(pathOrUrl);
+        if (await canLaunchUrl(uri)) {
+          await launchUrl(uri, mode: LaunchMode.externalApplication); // Open in external browser
+          print('Opened web URL: $pathOrUrl');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Opened web link: ${uri.host}')),
+          );
+        } else {
+          print('Could not launch web URL: $pathOrUrl');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Could not open web link: $pathOrUrl')),
+          );
+        }
+      } catch (e) {
+        print('Error parsing or launching URL: $e');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Invalid URL or error opening: $pathOrUrl')),
+        );
+      }
+    } else {
+      // Assume it's a local file path
+      String actualFilePath;
+      if (pathOrUrl.startsWith('file:///')) {
+        actualFilePath = Uri.decodeComponent(pathOrUrl.substring('file:///'.length));
+      } else {
+        actualFilePath = Uri.decodeComponent(pathOrUrl);
+      }
+      print('2. Detected as Local File Path: $actualFilePath. Attempting to open with OpenFilex.');
+
+      final File file = File(actualFilePath);
+
+      if (await file.exists()) {
+        print('3. Local file exists at path: $actualFilePath');
+        try {
+          final OpenResult result = await OpenFilex.open(actualFilePath);
+          print('4. OpenFilex result type: ${result.type}');
+          print('5. OpenFilex result message: ${result.message}');
+
+          if (result.type == ResultType.done) {
+            print('File opened successfully!');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Opened file: ${file.path.split('/').last}')),
+            );
+          } else {
+            print('Failed to open local file with OpenFilex. Error: ${result.message}');
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Could not open file: ${file.path.split('/').last}. Error: ${result.message}')),
+            );
+          }
+        } catch (e) {
+          print('6. Exception caught when trying to open local file with OpenFilex: $e');
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('An unexpected error occurred: ${e.toString()}')),
+          );
+        }
+      } else {
+        print('3. Local file DOES NOT exist at path: $actualFilePath');
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('File not found on device: ${file.path.split('/').last}')),
+        );
+      }
+    }
+    print('--- File Tap Debug End ---');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String pathOrUrl = message.message;
+
+    // Determine what to display based on whether it's a URL or a file path
+    String displayFileName;
+    IconData displayIcon;
+    Color iconColor = isMessageBySender ? Colors.blue[700]! : Colors.grey[700]!;
+    Color textColor = isMessageBySender ? Colors.blue[900]! : Colors.black87;
+
+    if (_isWebUrl(pathOrUrl)) {
+      displayFileName = Uri.parse(pathOrUrl).host; // Show domain for URL
+      displayIcon = Icons.link; // Link icon for URLs
+    } else {
+      // Treat as a local file path
+      String actualFilePath;
+      if (pathOrUrl.startsWith('file:///')) {
+        actualFilePath = Uri.decodeComponent(pathOrUrl.substring('file:///'.length));
+      } else {
+        actualFilePath = Uri.decodeComponent(pathOrUrl);
+      }
+      displayFileName = actualFilePath.split('/').last; // Show file name for local files
+      displayIcon = Icons.insert_drive_file; // Generic file icon
+    }
+
+    return GestureDetector(
+      onTap: () => _onFileTap(context, pathOrUrl),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        margin: EdgeInsets.only(
+          top: 6,
+          right: isMessageBySender ? 6 : 0,
+          left: isMessageBySender ? 0 : 6,
+          bottom: message.reaction.reactions.isNotEmpty ? 15 : 0,
+        ),
+        decoration: BoxDecoration(
+          color: isMessageBySender ? Colors.blue[100] : Colors.grey[300],
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              displayIcon,
+              color: iconColor,
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    displayFileName,
+                    style: TextStyle(
+                      color: textColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  // Conditional display for file size/status or URL status
+                  _isWebUrl(pathOrUrl)
+                      ? Text(
+                          'Web Link',
+                          style: const TextStyle(fontSize: 12, color: Colors.black54),
+                        )
+                      : FutureBuilder<bool>(
+                          future: File(pathOrUrl.startsWith('file:///') ? Uri.decodeComponent(pathOrUrl.substring('file:///'.length)) : Uri.decodeComponent(pathOrUrl)).exists(),
+                          builder: (context, snapshot) {
+                            if (snapshot.connectionState == ConnectionState.done) {
+                              if (snapshot.hasData && snapshot.data == true) {
+                                final file = File(pathOrUrl.startsWith('file:///') ? Uri.decodeComponent(pathOrUrl.substring('file:///'.length)) : Uri.decodeComponent(pathOrUrl));
+                                return Text(
+                                  'File exists (${(file.lengthSync() / 1024).toStringAsFixed(2)} KB)',
+                                  style: const TextStyle(fontSize: 12, color: Colors.black54),
+                                );
+                              } else {
+                                return Text(
+                                  'File not found',
+                                  style: const TextStyle(fontSize: 12, color: Colors.red),
+                                );
+                              }
+                            }
+                            return const Text('Checking file...', style: TextStyle(fontSize: 12, color: Colors.black54));
+                          },
+                        ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/message_view.dart
+++ b/lib/src/widgets/message_view.dart
@@ -32,6 +32,7 @@ import 'image_message_view.dart';
 import 'reaction_widget.dart';
 import 'text_message_view.dart';
 import 'voice_message_view.dart';
+import 'file_message_view.dart'; // ADD THIS IMPORT
 
 class MessageView extends StatefulWidget {
   const MessageView({
@@ -212,7 +213,18 @@ class _MessageViewState extends State<MessageView>
                     highlightImage: widget.shouldHighlight,
                     highlightScale: widget.highlightScale,
                   );
-                } else if (widget.message.messageType.isText) {
+                }
+                // ADDED THIS ELSE IF FOR MessageType.file
+                else if (widget.message.messageType == MessageType.file) {
+                  return FileMessageView(
+                    message: widget.message,
+                    isMessageBySender: widget.isMessageBySender,
+                    // You can add more configurations here if FileMessageView needs them
+                    // fileMessageConfig: messageConfig?.fileMessageConfig, // Uncomment if you add a fileMessageConfig to MessageConfiguration
+                  );
+                }
+                // END OF ADDED ELSE IF
+                else if (widget.message.messageType.isText) {
                   return TextMessageView(
                     inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
                     outgoingChatBubbleConfig: widget.outgoingChatBubbleConfig,
@@ -252,11 +264,11 @@ class _MessageViewState extends State<MessageView>
                         .lastSeenAgoBuilderVisibility ??
                     true) {
                   return widget.outgoingChatBubbleConfig?.receiptsWidgetConfig
-                          ?.lastSeenAgoBuilder
-                          ?.call(
-                              widget.message,
-                              applicationDateFormatter(
-                                  widget.message.createdAt)) ??
+                              ?.lastSeenAgoBuilder
+                              ?.call(
+                                  widget.message,
+                                  applicationDateFormatter(
+                                      widget.message.createdAt)) ??
                       lastSeenAgoBuilder(widget.message,
                           applicationDateFormatter(widget.message.createdAt));
                 }

--- a/lib/src/widgets/reply_message_type_view.dart
+++ b/lib/src/widgets/reply_message_type_view.dart
@@ -81,6 +81,23 @@ class ReplyMessageTypeView extends StatelessWidget {
             ),
           ],
         ),
+      // Case for MessageType.file - Corrected to use a hardcoded string for now
+      MessageType.file => Row(
+          children: [
+            Icon(
+              Icons.file_copy, // Or any other suitable file icon
+              size: 20,
+              color:
+                  sendMessageConfig?.replyMessageColor ?? Colors.grey.shade700,
+            ),
+            Text(
+              'File', // Changed from PackageStrings.currentLocale.file to a hardcoded string
+              style: TextStyle(
+                color: sendMessageConfig?.replyMessageColor ?? Colors.black,
+              ),
+            ),
+          ],
+        ),
       MessageType.custom when customMessageReplyViewBuilder != null =>
         customMessageReplyViewBuilder!(message),
       MessageType.custom || MessageType.text => Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,13 +19,15 @@ dependencies:
   any_link_preview: ^3.0.2
   audio_waveforms: ^1.2.0
   cached_network_image: ^3.4.1
-  chatview_utils: ^0.0.1
+  chatview_utils:
+    path: ../offline-chatview-utils 
   emoji_picker_flutter: ^4.3.0
   flutter:
     sdk: flutter
   image_picker: '>=0.8.9 <2.0.0'
   intl: ^0.20.0
   url_launcher: ^6.3.0
+  open_filex: ^4.3.2
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
### ✨ New Feature: Add File Message Type Support with Open File Capability and Enhanced Input Field Customization

**Video Recording**

https://github.com/user-attachments/assets/a89747a2-ca34-4d3d-aea1-648dbc7c93f5



**Description**
This pull request significantly enhances ChatView by introducing a new **file message type** and improving the customizability of the chat input field. Users can now send and receive files, with the added functionality to open these files directly from the chat interface. Additionally, the existing `trailing` parameter of the text field is highlighted as a powerful way to add custom icons, such as a file picker, to the chat composer.

**FEATURES**
1.  **File Message Type and File Opening on Tap**
    This feature introduces the capability to handle and display messages that represent files. A new `FileMessageView` widget is integrated to render these messages. Furthermore, users can now open these files directly from the chat UI by tapping on the message, facilitated by the `open_filex` package. The reply message view also supports a distinct display for file messages.
    
    **Screenshots**

    ![image](https://github.com/user-attachments/assets/7e5308c6-356a-41bd-ba5c-776604b8254f)

    ![image](https://github.com/user-attachments/assets/68c3dbcf-ddfd-4d74-a2b6-95f607fe8ef9)


    **Code**
    ```diff
    --- a/lib\src\widgets\message_view.dart
    +++ b/lib\src\widgets\message_view.dart
    @@ -16,6 +16,7 @@
     import 'image_message_view.dart';
     import 'reaction_widget.dart';
     import 'text_message_view.dart';
     import 'voice_message_view.dart';
     import 'file_message_view.dart'; // ADD THIS IMPORT
     
     class MessageView extends StatefulWidget {
    @@ -140,6 +141,15 @@
                                           highlightScale: widget.highlightScale,
                       );
                     }
    +                // ADDED THIS ELSE IF FOR MessageType.file
    +                else if (widget.message.messageType == MessageType.file) {
    +                  return FileMessageView(
    +                    message: widget.message,
    +                    isMessageBySender: widget.isMessageBySender,
    +                    // You can add more configurations here if FileMessageView needs them
    +                    // fileMessageConfig: messageConfig?.fileMessageConfig, // Uncomment if you add a fileMessageConfig to MessageConfiguration
    +                  );
    +                }
    +                // END OF ADDED ELSE IF
                     else if (widget.message.messageType.isText) {
                       return TextMessageView(
                         inComingChatBubbleConfig: widget.inComingChatBubbleConfig,
    ```
    ```diff
    --- a/lib\src\widgets\reply_message_type_view.dart
    +++ b/lib\src\widgets\reply_message_type_view.dart
    @@ -52,6 +52,21 @@
                   ),
               ],
             ),
    +      // Case for MessageType.file - Corrected to use a hardcoded string for now
    +      MessageType.file => Row(
    +          children: [
    +            Icon(
    +              Icons.file_copy, // Or any other suitable file icon
    +              size: 20,
    +              color:
    +                  sendMessageConfig?.replyMessageColor ?? Colors.grey.shade700,
    +            ),
    +            Text(
    +              'File', // Changed from PackageStrings.currentLocale.file to a hardcoded string
    +              style: TextStyle(
    +                color: sendMessageConfig?.replyMessageColor ?? Colors.black,
    +              ),
    +            ),
    +          ],
    +        ),
           MessageType.custom when customMessageReplyViewBuilder != null =>
             customMessageReplyViewBuilder!(message),
           MessageType.custom || MessageType.text => Text(
    ```
    ```diff
    --- a/pubsec.yaml
    +++ b/pubsec.yaml
    @@ -23,6 +23,7 @@
       image_picker: '>=0.8.9 <2.0.0'
       intl: ^0.20.0
       url_launcher: ^6.3.0
    +  open_filex: ^4.3.2
     
     dev_dependencies:
       flutter_lints: ^2.0.1
    ```

2.  **Enhanced Input Field Customization via `trailing` parameter**
    This feature leverages the existing `trailing` parameter within `SendMessageConfiguration` to provide greater flexibility for adding custom widgets to the chat input field. Developers can now easily integrate elements like a file attachment icon, stickers button, or any other custom functionality directly into the message composer's right side.
    
     **Screenshots**

    
     ![image](https://github.com/user-attachments/assets/1d636801-36b6-4cdf-964b-b62eebec8ea6)



    **Code**
    ```dart
    // In lib\src\widgets\chatui_textfield.dart, within the build method's Row widget:
    if (sendMessageConfig?.trailing != null)
      ...sendMessageConfig!.trailing!,
    ```

## Checklist
- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.


## Related Issues
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org