### PR TITLE
feat: ✨ Add `headerSlivers` support to `ChatList` for advanced pinned headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   Rendering issue in attached image preview when sending message on web.
 * **Feat**: [420](https://github.com/SimformSolutionsPvtLtd/chatview/pull/420) Added support for
   `playerMode` in `VoiceMessageConfiguration` with `single` and `multi`.
+* **Feat**: [429](https://github.com/SimformSolutionsPvtLtd/chatview/pull/429) Added optional `headerSlivers`
+  to `ChatList` for better customization.
 
 ## [3.0.0]
 

--- a/lib/src/widgets/chat_list/chat_list.dart
+++ b/lib/src/widgets/chat_list/chat_list.dart
@@ -56,6 +56,7 @@ class ChatList extends StatefulWidget {
     this.chatBuilder,
     this.appbar,
     this.loadMoreChats,
+    this.headerSlivers,
     this.header,
     this.footer,
     this.isLastPage,
@@ -82,6 +83,9 @@ class ChatList extends StatefulWidget {
   /// Defaults to `false`.
   /// If set to `true`, pagination will not trigger loading more chats.
   final ValueGetter<bool>? isLastPage;
+
+  /// List of sliver headers to be displayed at the top of the chat list.
+  final List<Widget>? headerSlivers;
 
   /// Header widget to be displayed at the top of the chat list.
   final Widget? header;
@@ -179,6 +183,7 @@ class _ChatListState extends State<ChatList> {
               ),
             ),
           ),
+        ...?widget.headerSlivers,
         if (widget.header case final header?) SliverToBoxAdapter(child: header),
         StreamBuilder<List<ChatListItem>>(
           stream: _controller.chatListStream,

--- a/lib/src/widgets/chat_list/chat_list.dart
+++ b/lib/src/widgets/chat_list/chat_list.dart
@@ -85,6 +85,9 @@ class ChatList extends StatefulWidget {
   final ValueGetter<bool>? isLastPage;
 
   /// List of sliver headers to be displayed at the top of the chat list.
+  /// 
+  /// Each widget in this list must be a sliver widget that builds a
+  /// [RenderSliver] (e.g. [SliverAppBar], [SliverPersistentHeader], etc.)
   final List<Widget>? headerSlivers;
 
   /// Header widget to be displayed at the top of the chat list.


### PR DESCRIPTION
## Summary

This PR adds a new optional `headerSlivers` parameter to `ChatList`, allowing consumers to provide multiple slivers (e.g. SliverAppBar, SliverPersistentHeader) before the chat list. This make the `ChatList` more customizable.

## Checklist

* [x]  The title of my PR starts with a [Conventional Commit](https://conventionalcommits.org) prefix (`fix:`, `feat:`, `docs:` etc).
* [x]  I have followed the [Contributor Guide](https://github.com/SimformSolutionsPvtLtd/chatview/blob/main/CONTRIBUTING.md) when preparing my PR.
* [ ]  I have updated/added tests for ALL new/updated/fixed functionality.
* [x]  I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
* [ ]  I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

* [ ]  Yes, this PR is a breaking change.
* [x]  No, this PR is not a breaking change.