### PR TITLE
feat: add optional boxShadow to ChatBubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   Rendering issue in attached image preview when sending message on web.
 * **Feat**: [420](https://github.com/SimformSolutionsPvtLtd/chatview/pull/420) Added support for
   `playerMode` in `VoiceMessageConfiguration` with `single` and `multi`.
+* **Feat**: [433](https://github.com/SimformSolutionsPvtLtd/chatview/pull/XXX) Add optional
+  `boxShadow` to `ChatBubble` and apply it in `TextMessageView` when set.
 
 ## [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
   Rendering issue in attached image preview when sending message on web.
 * **Feat**: [420](https://github.com/SimformSolutionsPvtLtd/chatview/pull/420) Added support for
   `playerMode` in `VoiceMessageConfiguration` with `single` and `multi`.
-* **Feat**: [433](https://github.com/SimformSolutionsPvtLtd/chatview/pull/XXX) Add optional
+* **Feat**: [434](https://github.com/SimformSolutionsPvtLtd/chatview/pull/434) Add optional
   `boxShadow` to `ChatBubble` and apply it in `TextMessageView` when set.
 
 ## [3.0.0]

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -766,6 +766,13 @@ class _ExampleOneChatScreenState extends State<ExampleOneChatScreen> {
               receiptsWidgetConfig: ReceiptsWidgetConfig(
                 showReceiptsIn: ShowReceiptsIn.lastMessage,
               ),
+              boxShadow: [
+                BoxShadow(
+                  color: Color(0x40000000),
+                  blurRadius: 10,
+                  offset: Offset(0, 2),
+                ),
+              ],
             ),
             inComingChatBubbleConfig: ChatBubble(
               linkPreviewConfig: LinkPreviewConfiguration(

--- a/lib/src/models/chat_bubble.dart
+++ b/lib/src/models/chat_bubble.dart
@@ -39,6 +39,7 @@ class ChatBubble {
     this.onMessageRead,
     this.border,
     this.textSelectionConfig,
+    this.boxShadow,
   });
 
   /// Used for giving color of chat bubble.
@@ -75,4 +76,9 @@ class ChatBubble {
 
   /// Configuration for text selection behavior and appearance.
   final TextSelectionConfig? textSelectionConfig;
+
+  /// Optional shadow(s) drawn under the chat bubble.
+  ///
+  /// When null, no shadow is applied (default behavior).
+  final List<BoxShadow>? boxShadow;
 }

--- a/lib/src/widgets/text_message_view.dart
+++ b/lib/src/widgets/text_message_view.dart
@@ -119,6 +119,9 @@ class TextMessageView extends StatelessWidget {
             color: highlightMessage ? highlightColor : _color,
             border: border,
             borderRadius: _borderRadius(textMessage),
+            boxShadow: isMessageBySender
+                ? outgoingChatBubbleConfig?.boxShadow
+                : inComingChatBubbleConfig?.boxShadow,
           ),
           child: isSelectable
               ? CustomSelectionArea(


### PR DESCRIPTION
# Description

Adds an optional `boxShadow` field to `ChatBubble` and wires it into `TextMessageView`’s `BoxDecoration` for outgoing and incoming bubbles when set.

**Existing behavior:** Text bubbles only supported `color`, `borderRadius`, `border`, padding/margin, etc.; there was no supported way to add a drop shadow without forking.

**This PR:** When `boxShadow` is `null` (default), appearance is unchanged. When set, the configured `List<BoxShadow>` is applied to the text message bubble.

**Motivation:** Allows apps to add subtle elevation/shadow for readability and visual hierarchy without patching the package.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

<!-- Add if you opened or found an issue, e.g. Closes #1234 -->