### PR TITLE
fix: Expose isEditMode to leadingActions/trailingActions builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 * **Feat**: [454](https://github.com/SimformSolutionsPvtLtd/chatview/pull/454) :sparkles: Add configurable image fit option for AdaptiveImage widget
+* **Fix**: [456](https://github.com/SimformSolutionsPvtLtd/chatview/pull/456) Expose isEditMode to leadingActions/trailingActions builders
 
 ## 3.1.0
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -1302,11 +1302,14 @@ You can now add action buttons to the input field using two builders:
 - `trailingActions`: widgets shown after the text field.
 
 Use built‑in `CameraActionButton`, `GalleryActionButton`, and optionally an `OverlayActionButton`
-that groups multiple `OverlayActionWidget`s. Place them on either side as needed. Example below:
+that groups multiple `OverlayActionWidget`s. Place them on either side as needed.
+
+Both builders receive an `isEditMode` flag (`true` while a message is being edited), so you can
+show, hide, or swap actions based on edit state. Example below:
 
 ```dart
 textFieldConfig: TextFieldConfiguration(
-  trailingActions: (context, controller) {
+  trailingActions: (context, controller, isEditMode) {
     return [
       CameraActionButton(
         icon: const Icon(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -640,64 +640,75 @@ class _ExampleOneChatScreenState extends State<ExampleOneChatScreen> {
               compositionThresholdTime: const Duration(seconds: 1),
               textStyle: TextStyle(color: _theme.textColor),
               contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-              leadingActions: (context, controller) =>
-                  controller.text.trim().isEmpty
-                      ? [
-                          CameraActionButton(
-                            icon: const Icon(
-                              Icons.camera_alt_rounded,
-                              color: Colors.white,
-                            ),
-                            style: IconButton.styleFrom(
-                              backgroundColor: AppColors.uiOnePurple,
-                            ),
-                            onPressed: (path, replyMessage) {
-                              if (path?.isEmpty ?? true) return;
-                              _chatController.addMessage(
-                                Message(
-                                  id: DateTime.now()
-                                      .millisecondsSinceEpoch
-                                      .toString(),
-                                  message: path!,
-                                  createdAt: DateTime.now(),
-                                  messageType: MessageType.image,
-                                  sentBy: _chatController.currentUser.id,
-                                  replyMessage:
-                                      replyMessage ?? const ReplyMessage(),
-                                ),
-                              );
-                              _chatController.addMessage(
-                                Message(
-                                  message: controller.text,
-                                  id: DateTime.now()
-                                      .millisecondsSinceEpoch
-                                      .toString(),
-                                  createdAt: DateTime.now(),
-                                  sentBy: _chatController.currentUser.id,
-                                  replyMessage:
-                                      replyMessage ?? const ReplyMessage(),
-                                ),
-                              );
-                            },
+              leadingActions: (context, controller, isEditing) {
+                if (controller.text.trim().isEmpty) {
+                  return [
+                    CameraActionButton(
+                      icon: const Icon(
+                        Icons.camera_alt_rounded,
+                        color: Colors.white,
+                      ),
+                      style: IconButton.styleFrom(
+                        backgroundColor: AppColors.uiOnePurple,
+                      ),
+                      onPressed: (path, replyMessage) {
+                        if (path?.isEmpty ?? true) return;
+                        final now = DateTime.now();
+                        _chatController.addMessage(
+                          Message(
+                            id: '${now.millisecondsSinceEpoch}_img',
+                            message: path!,
+                            createdAt: now,
+                            messageType: MessageType.image,
+                            sentBy: _chatController.currentUser.id,
+                            replyMessage: replyMessage ?? const ReplyMessage(),
                           ),
-                        ]
-                      : [
-                          IconButton(
-                            icon: const Icon(
-                              Icons.search_rounded,
-                              color: Colors.white,
-                            ),
-                            style: IconButton.styleFrom(
-                              backgroundColor: AppColors.uiOnePurple,
-                            ),
-                            onPressed: () =>
-                                ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                  content: Text('Search button pressed')),
-                            ),
+                        );
+                        _chatController.addMessage(
+                          Message(
+                            message: controller.text,
+                            id: '${now.millisecondsSinceEpoch}_txt',
+                            createdAt: now,
+                            sentBy: _chatController.currentUser.id,
+                            replyMessage: replyMessage ?? const ReplyMessage(),
                           ),
-                        ],
-              trailingActions: (context, controller) => [
+                        );
+                      },
+                    ),
+                  ];
+                } else if (isEditing) {
+                  return [
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: const BoxDecoration(
+                        color: AppColors.uiOnePurple,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.edit,
+                        color: Colors.white,
+                      ),
+                    )
+                  ];
+                } else {
+                  return [
+                    IconButton(
+                      icon: const Icon(
+                        Icons.search_rounded,
+                        color: Colors.white,
+                      ),
+                      style: IconButton.styleFrom(
+                        backgroundColor: AppColors.uiOnePurple,
+                      ),
+                      onPressed: () =>
+                          ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Search button pressed')),
+                      ),
+                    ),
+                  ];
+                }
+              },
+              trailingActions: (context, controller, isEditing) => [
                 GalleryActionButton(
                   icon: Icon(
                     Icons.photo_rounded,

--- a/lib/src/values/typedefs.dart
+++ b/lib/src/values/typedefs.dart
@@ -112,6 +112,7 @@ typedef ChatTextFieldViewBuilderCallback<T> = Widget Function(
 typedef TextFieldActionWidgetBuilder = List<Widget> Function(
   BuildContext context,
   TextEditingController controller,
+  bool isEditMode,
 );
 typedef BackgroundImageLoadError = void Function(
   Object exception,

--- a/lib/src/widgets/chatui_textfield.dart
+++ b/lib/src/widgets/chatui_textfield.dart
@@ -47,6 +47,7 @@ class ChatUITextField extends StatefulWidget {
     required this.onRecordingComplete,
     required this.onImageSelected,
     required this.sendMessageConfig,
+    required this.isEditModeNotifier,
     super.key,
   });
 
@@ -67,6 +68,9 @@ class ChatUITextField extends StatefulWidget {
 
   /// Provides callback when user select images from camera/gallery.
   final StringsCallBack onImageSelected;
+
+  /// Notifier for whether the text field is in edit mode.
+  final ValueNotifier<bool> isEditModeNotifier;
 
   @override
   State<ChatUITextField> createState() => _ChatUITextFieldState();
@@ -240,23 +244,29 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                   child: Row(
                     children: [
                       ValueListenableBuilder(
-                        valueListenable: _isTextNotEmptyNotifier,
-                        builder: (context, isNotEmpty, _) {
-                          final hideLeadingActions =
-                              (textFieldConfig?.hideLeadingActionsOnType ??
-                                      false) &&
-                                  isNotEmpty;
-                          if (hideLeadingActions) {
-                            return const SizedBox.shrink();
-                          }
-                          final actions = textFieldConfig?.leadingActions?.call(
-                            context,
-                            widget.textEditingController,
-                          );
-                          return actions == null
-                              ? const SizedBox.shrink()
-                              : Row(children: actions);
-                        },
+                        valueListenable: widget.isEditModeNotifier,
+                        builder: (context, isEditing, _) =>
+                            ValueListenableBuilder(
+                          valueListenable: _isTextNotEmptyNotifier,
+                          builder: (context, isNotEmpty, _) {
+                            final hideLeadingActions =
+                                (textFieldConfig?.hideLeadingActionsOnType ??
+                                        false) &&
+                                    isNotEmpty;
+                            if (hideLeadingActions) {
+                              return const SizedBox.shrink();
+                            }
+                            final actions =
+                                textFieldConfig?.leadingActions?.call(
+                              context,
+                              widget.textEditingController,
+                              isEditing,
+                            );
+                            return actions == null
+                                ? const SizedBox.shrink()
+                                : Row(children: actions);
+                          },
+                        ),
                       ),
                       Expanded(
                         child: TextField(
@@ -321,6 +331,7 @@ class _ChatUITextFieldState extends State<ChatUITextField> {
                           ...textFieldConfig?.trailingActions?.call(
                                 context,
                                 widget.textEditingController,
+                                widget.isEditModeNotifier.value,
                               ) ??
                               [
                                 CameraActionButton(

--- a/lib/src/widgets/send_message_widget.dart
+++ b/lib/src/widgets/send_message_widget.dart
@@ -87,6 +87,8 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
   /// The message currently being edited, or `null` if not in edit mode.
   Message? _currentlyEditingMessage;
 
+  final _isEditModeNotifier = ValueNotifier<bool>(false);
+
   /// Whether the text field is currently in edit mode.
   bool get isEditMode => _currentlyEditingMessage != null;
 
@@ -193,6 +195,7 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
                                     _textEditingController.clear();
                                   }
                                   _currentlyEditingMessage = value;
+                                  _isEditModeNotifier.value = value != null;
                                 },
                               ),
                               if (widget
@@ -206,6 +209,7 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
                                 textEditingController: _textEditingController,
                                 onPressed: _onPressed,
                                 sendMessageConfig: widget.sendMessageConfig,
+                                isEditModeNotifier: _isEditModeNotifier,
                                 onRecordingComplete: _onRecordingComplete,
                                 onImageSelected: (images, messageId) {
                                   if (widget.sendMessageConfig
@@ -389,6 +393,7 @@ class SendMessageWidgetState extends State<SendMessageWidget> {
   void dispose() {
     _textEditingController.dispose();
     _focusNode.dispose();
+    _isEditModeNotifier.dispose();
     super.dispose();
   }
 }


### PR DESCRIPTION
# Description
<!--
Provide a description of what this PR is doing.
If you're modifying existing behavior, describe the existing behavior, how this PR is changing it,
and what motivated the change. If this is a breaking change, specify explicitly which APIs were
changed.
-->

Pass isEditing bool to TextFieldActionWidgetBuilder so callers can hide/show actions based on edit state. Add ValueNotifier<bool> in SendMessageWidgetState to drive reactive updates.

User can add there custom leading widget 
<img width="300"  alt="Simulator Screenshot - iPhone 16e - 2026-06-16 at 12 56 44" src="https://github.com/user-attachments/assets/9fe09000-29bb-452e-ae38-9bdfafc2f5a2" />

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[ ]`.
-->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples` or `docs`.


## Breaking Change?
<!--
Would your PR require ChatView users to update their apps following your change?
If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
### Migration instructions
If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version to the new proposed way.
-->

- [x] Yes, this PR is a breaking change.
- [ ] No, this PR is not a breaking change.


## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:
Closes #1234
!-->

<!-- Links -->
[Contributor Guide]: https://github.com/SimformSolutionsPvtLtd/chatview/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org